### PR TITLE
Format and fix a typo in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,10 +1,10 @@
 # Contributions
 
-* [**Wilson Kurniawan**](https://github.com/wkurniawan07) - Wrote the [initial version of this website](https://github.com/wkurniawan07/website) [2015] .
+* [**Wilson Kurniawan**](https://github.com/wkurniawan07) - Wrote the [initial version of this website](https://github.com/wkurniawan07/website). [2015]
 
-* [**Xianyan Jia**](https://github.com/SeaOfOcean) - Helped to convert the Handbook page [2015]
-* [**Chencan Xu**](https://github.com/cxuc163)- Helped to convert the Handbook page [2015]
-* [**Soh You Jun**](https://github.com/yj-soh) - Helped to convert part of the Schedle page. Suggested improvements. [2015]
+* [**Xianyan Jia**](https://github.com/SeaOfOcean) - Helped to convert the Handbook page. [2015]
+* [**Chencan Xu**](https://github.com/cxuc163) - Helped to convert the Handbook page. [2015]
+* [**Soh You Jun**](https://github.com/yj-soh) - Helped to convert part of the Schedule page. Suggested improvements. [2015]
 
 
 `//more to be added`


### PR DESCRIPTION
- Fixed typo: "Schedle" -> "Schedule"
- Fixed spacing discrepancy in line 6.
- Standardized period usage.