### PR TITLE
Handbook 'jump to section' hides the section title under the nav bar #20

### DIFF
--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -11,3 +11,12 @@ for (var i in sections) {
         }
     });
 }
+
+$('a').click(function() {
+    var adjustment = 73;
+    var speed = 1;
+    var header = this.hash;
+    $('html,body').animate({
+        scrollTop: $(header).offset().top - adjustment
+    }, speed);
+});


### PR DESCRIPTION
Fixes #20 using jQuery animate() method.