### PR TITLE
Handbook TOC links are not working in iPhone browser #19

### DIFF
--- a/contents/handbook.html
+++ b/contents/handbook.html
@@ -22,225 +22,225 @@
 
 
 <ul>
-    <li><a href="#handbook-preliminaries">Preliminaries</a></li>
-    <li><a href="#handbook-lectures">Lectures</a></li>
-    <li><a href="#handbook-tutorials">Tutorials</a></li>
-    <li><a href="#handbook-textBooks">Text Books</a></li>
-    <li><a href="#handbook-programmingLanguages">Programming Language</a></li>
-    <li><a href="#handbook-project">Project</a></li>
+    <li><a href="#preliminaries">Preliminaries</a></li>
+    <li><a href="#lectures">Lectures</a></li>
+    <li><a href="#tutorials">Tutorials</a></li>
+    <li><a href="#textBooks">Text Books</a></li>
+    <li><a href="#programmingLanguages">Programming Language</a></li>
+    <li><a href="#project">Project</a></li>
     <ul>
-        <li><a href="#handbook-theProduct">The product</a></li>
-        <li><a href="#handbook-projectScope">Project Scope</a></li>
-        <li><a href="#handbook-projectConstraints">Project Constraints</a></li>
-        <li><a href="#handbook-deliveables">Deliverables</a></li>
+        <li><a href="#theProduct">The product</a></li>
+        <li><a href="#projectScope">Project Scope</a></li>
+        <li><a href="#projectConstraints">Project Constraints</a></li>
+        <li><a href="#deliveables">Deliverables</a></li>
         <ul>
-            <li><a href="#handbook-ce1">CE1: TextBuddy</a></li>
-            <li><a href="#handbook-ce2">CE2: TextBuddy++</a></li>
-            <li><a href="#handbook-ce3">CE3: TextBuddyPro</a></li>
-            <li><a href="#handbook-v00Manual">V0.0 of the Project Manual</a></li>
-            <li><a href="#handbook-v01Product">V0.1 : the proof-of-concept prototype</a></li>
-            <li><a href="#handbook-v01Demo">V0.1 Demo</a></li>
-            <li><a href="#handbook-v01Manual">V0.1 of the Project Manual</a></li>
-            <li><a href="#handbook-v02Demo">V0.2 Demo and Feedback Session</a></li>
-            <li><a href="#handbook-v02Manual">V0.2-V0.4 of the Project Manual</a></li>
-            <li><a href="#handbook-v02Product">V0.2-V0.4 of the Product</a></li>
-            <li><a href="#handbook-v02Grading">V0.2-V0.4 Grading</a></li>
-            <li><a href="#handbook-v04Product">V0.4 [release candidate] Additional Requirements</a></li>
-            <li><a href="#handbook-v05Requirements">V0.5 [production release] Additional Requirements</a></li>
-            <li><a href="#handbook-v05Submission">V0.5 Submission</a></li>
-            <li><a href="#handbook-v05Demo">V0.5 Demo and Q&A Session</a></li>
-            <li><a href="#handbook-projectRetrospective">Project retrospective</a></li>
-            <li><a href="#handbook-individualReport">Individual report</a></li>
-            <li><a href="#handbook-v05Evaluation">V0.5 Evaluation</a></li>
+            <li><a href="#ce1">CE1: TextBuddy</a></li>
+            <li><a href="#ce2">CE2: TextBuddy++</a></li>
+            <li><a href="#ce3">CE3: TextBuddyPro</a></li>
+            <li><a href="#v00Manual">V0.0 of the Project Manual</a></li>
+            <li><a href="#v01Product">V0.1 : the proof-of-concept prototype</a></li>
+            <li><a href="#v01Demo">V0.1 Demo</a></li>
+            <li><a href="#v01Manual">V0.1 of the Project Manual</a></li>
+            <li><a href="#v02Demo">V0.2 Demo and Feedback Session</a></li>
+            <li><a href="#v02Manual">V0.2-V0.4 of the Project Manual</a></li>
+            <li><a href="#v02Product">V0.2-V0.4 of the Product</a></li>
+            <li><a href="#v02Grading">V0.2-V0.4 Grading</a></li>
+            <li><a href="#v04Product">V0.4 [release candidate] Additional Requirements</a></li>
+            <li><a href="#v05Requirements">V0.5 [production release] Additional Requirements</a></li>
+            <li><a href="#v05Submission">V0.5 Submission</a></li>
+            <li><a href="#v05Demo">V0.5 Demo and Q&A Session</a></li>
+            <li><a href="#projectRetrospective">Project retrospective</a></li>
+            <li><a href="#individualReport">Individual report</a></li>
+            <li><a href="#v05Evaluation">V0.5 Evaluation</a></li>
         </ul>
-        <li><a href="#handbook-formingTeams">Forming Teams</a></li>
-        <li><a href="#handbook-supervision">Supervision</a></li>
-        <li><a href="#handbook-projectGrading">Project Grading</a></li>
-        <li><a href="#handbook-peerEvaluations">Peer Evaluations</a></li>
-        <li><a href="#handbook-projectTools">Project Tools</a></li>
+        <li><a href="#formingTeams">Forming Teams</a></li>
+        <li><a href="#supervision">Supervision</a></li>
+        <li><a href="#projectGrading">Project Grading</a></li>
+        <li><a href="#peerEvaluations">Peer Evaluations</a></li>
+        <li><a href="#projectTools">Project Tools</a></li>
     </ul>
-    <li><a href="#handbook-exams">Exams</a></li>
-    <li><a href="#handbook-gradeBreakdown">Grade Breakdown</a></li>
-    <li><a href="#handbook-participationPoints">Participation Points</a></li>
-    <li><a href="#handbook-appendixA">Appendix A: Module Principles</a></li>
-    <li><a href="#handbook-appendixB">Appendix B: Module Policies</a></li>
+    <li><a href="#exams">Exams</a></li>
+    <li><a href="#gradeBreakdown">Grade Breakdown</a></li>
+    <li><a href="#participationPoints">Participation Points</a></li>
+    <li><a href="#appendixA">Appendix A: Module Principles</a></li>
+    <li><a href="#appendixB">Appendix B: Module Policies</a></li>
     <ul>
-        <li><a href="#handbook-policy-followingInstructions">Policy on following instructions</a></li>
-        <li><a href="#handbook-policy-teamSize">Policy on grading smaller/larger teams</a></li>
-        <li><a href="#handbook-policy-workDistribution">Policy on project work distribution</a></li>
-        <li><a href="#handbook-policy-validAbsences">Policy on absence due to valid reasons (e.g. MC, LOA, University events)</a></li>
-        <li><a href="#handbook-policy-responseTime">Policy on email response time</a></li>
-        <li><a href="#handbook-policy-techHelp">Policy on tech help</a></li>
-        <li><a href="#handbook-policy-publishingSubmissions">Policy on publishing submissions</a></li>
-        <li><a href="#handbook-policy-plagiarism">Policy on plagiarism</a></li>
-        <li><a href="#handbook-policy-reuse">Policy on reuse</a></li>
-        <li><a href="#handbook-policy-outsiderHelp">Policy on help from outsiders</a></li>
-        <li><a href="#handbook-policy-submissionLength">Policy on suggested length for submissions</a></li>
+        <li><a href="#policy-followingInstructions">Policy on following instructions</a></li>
+        <li><a href="#policy-teamSize">Policy on grading smaller/larger teams</a></li>
+        <li><a href="#policy-workDistribution">Policy on project work distribution</a></li>
+        <li><a href="#policy-validAbsences">Policy on absence due to valid reasons (e.g. MC, LOA, University events)</a></li>
+        <li><a href="#policy-responseTime">Policy on email response time</a></li>
+        <li><a href="#policy-techHelp">Policy on tech help</a></li>
+        <li><a href="#policy-publishingSubmissions">Policy on publishing submissions</a></li>
+        <li><a href="#policy-plagiarism">Policy on plagiarism</a></li>
+        <li><a href="#policy-reuse">Policy on reuse</a></li>
+        <li><a href="#policy-outsiderHelp">Policy on help from outsiders</a></li>
+        <li><a href="#policy-submissionLength">Policy on suggested length for submissions</a></li>
     </ul>
-    <li><a href="#handbook-appendixC">Appendix C: Frequently Asked Questions</a></li>
+    <li><a href="#appendixC">Appendix C: Frequently Asked Questions</a></li>
     <ul>
-        <li><a href="#handbook-faq-highWorkload">Why the workload is so high?</a></li>
-        <li><a href="#handbook-faq-beanCounting">Why so much bean counting?</a></li>
-        <li><a href="#handbook-faq-separateWebsite">Why you force me to visit a separate website instead of using IVLE?</a></li>
-        <li><a href="#handbook-faq-slideFormat">Why slides are not detailed enough, handouts are wordy?</a></li>
-        <li><a href="#handbook-faq-selfStudy">Why so much self-study?</a></li>
-        <li><a href="#handbook-faq-timelyArrival">Why do I have to come to tutorials on time?</a></li>
-        <li><a href="#handbook-faq-noLaptop">What if I don’t carry around a laptop?</a></li>
-        <li><a href="#handbook-faq-narrowScope">Why very narrow project scope?</a></li>
-        <li><a href="#handbook-faq-vagueRequirements">Why project requirements are so vague?</a></li>
-        <li><a href="#handbook-faq-favoriteTool">Why I’m not allowed to use my favorite OS/IDE/etc?</a></li>
-        <li><a href="#handbook-faq-manySubmissions">Why so many submissions?</a></li>
-        <li><a href="#handbook-faq-intermediateMarks">Why not enough marks for intermediate submissions?</a></li>
-        <li><a href="#handbook-faq-cs2101Differences">Why submission requirements differ between CS2103T and CS2101?</a></li>
+        <li><a href="#faq-highWorkload">Why the workload is so high?</a></li>
+        <li><a href="#faq-beanCounting">Why so much bean counting?</a></li>
+        <li><a href="#faq-separateWebsite">Why you force me to visit a separate website instead of using IVLE?</a></li>
+        <li><a href="#faq-slideFormat">Why slides are not detailed enough, handouts are wordy?</a></li>
+        <li><a href="#faq-selfStudy">Why so much self-study?</a></li>
+        <li><a href="#faq-timelyArrival">Why do I have to come to tutorials on time?</a></li>
+        <li><a href="#faq-noLaptop">What if I don’t carry around a laptop?</a></li>
+        <li><a href="#faq-narrowScope">Why very narrow project scope?</a></li>
+        <li><a href="#faq-vagueRequirements">Why project requirements are so vague?</a></li>
+        <li><a href="#faq-favoriteTool">Why I’m not allowed to use my favorite OS/IDE/etc?</a></li>
+        <li><a href="#faq-manySubmissions">Why so many submissions?</a></li>
+        <li><a href="#faq-intermediateMarks">Why not enough marks for intermediate submissions?</a></li>
+        <li><a href="#faq-cs2101Differences">Why submission requirements differ between CS2103T and CS2101?</a></li>
     </ul>
-    <li><a href="#handbook-appendixD">Appendix D: How to get tech help in CS2103/T</a></li>
-    <li><a href="#handbook-appendixE">Appendix E: Using GitHub Project Hosting</a></li>
-    <li><a href="#handbook-appendixF">Appendix F: What to do if there are teamwork issues</a></li>
+    <li><a href="#appendixD">Appendix D: How to get tech help in CS2103/T</a></li>
+    <li><a href="#appendixE">Appendix E: Using GitHub Project Hosting</a></li>
+    <li><a href="#appendixF">Appendix F: What to do if there are teamwork issues</a></li>
 </ul>
 
 
 
     <h1>Preliminaries </h1>
-    <div id="handbook-preliminaries"></div>
+    <div id="preliminaries"></div><div id="handbook-preliminaries"></div>
     <h1>Lectures </h1>
-    <div id="handbook-lectures"></div>
+    <div id="lectures"></div><div id="handbook-lectures"></div>
     <h1>Tutorials </h1>
-    <div id="handbook-tutorials"></div>
+    <div id="tutorials"></div><div id="handbook-tutorials"></div>
     <h1>Text Books </h1>
-    <div id="handbook-textBooks"></div>
+    <div id="textBooks"></div><div id="handbook-textBooks"></div>
     <h1>Programming Language </h1>
-    <div id="handbook-programmingLanguages"></div>
+    <div id="programmingLanguages"></div><div id="handbook-programmingLanguages"></div>
     <h1>Project </h1>
-    <div id="handbook-project"></div>
+    <div id="project"></div><div id="handbook-project"></div>
 
     <h2>The product</h2>
-    <div id="handbook-theProduct" ></div>
+    <div id="theProduct" ></div><div id="handbook-theProduct" ></div>
     <h2>Project Scope</h2>
-    <div id="handbook-projectScope" ></div>
+    <div id="projectScope" ></div><div id="handbook-projectScope" ></div>
     <h2>Project Constraints</h2>
-    <div id="handbook-projectConstraints" ></div>
+    <div id="projectConstraints" ></div><div id="handbook-projectConstraints" ></div>
     <h2>Deliverables</h2>
-    <div id="handbook-deliveables" ></div>
+    <div id="deliveables" ></div><div id="handbook-deliveables" ></div>
 
     <h3>CE1: TextBuddy</h3>
-    <div id="handbook-ce1"></div>
+    <div id="ce1"></div><div id="handbook-ce1"></div>
     <h3>CE2: TextBuddy++</h3>
-    <div id="handbook-ce2"></div>
+    <div id="ce2"></div><div id="handbook-ce2"></div>
     <h3>CE3: TextBuddyPro</h3>
-    <div id="handbook-ce3"></div>
+    <div id="ce3"></div><div id="handbook-ce3"></div>
     <h3>V0.0 of the Project Manual</h3>
-    <div id="handbook-v00Manual"></div>
+    <div id="v00Manual"></div><div id="handbook-v00Manual"></div>
     <h3>V0.1 : the proof-of-concept prototype</h3>
-    <div id="handbook-v01Product"></div>
+    <div id="v01Product"></div><div id="handbook-v01Product"></div>
     <h3>V0.1 Demo</h3>
-    <div id="handbook-v01Demo"></div>
+    <div id="v01Demo"></div><div id="handbook-v01Demo"></div>
     <h3>V0.1 of the Project Manual</h3>
-    <div id="handbook-v01Manual"></div>
+    <div id="v01Manual"></div><div id="handbook-v01Manual"></div>
     <h3>V0.2 Demo and Feedback Session</h3>
-    <div id="handbook-v02Demo"></div>
+    <div id="v02Demo"></div><div id="handbook-v02Demo"></div>
     <h3>V0.2-V0.4 of the Project Manual</h3>
-    <div id="handbook-v02Manual"></div>
+    <div id="v02Manual"></div><div id="handbook-v02Manual"></div>
     <h3>V0.2-V0.4 of the Product</h3>
-    <div id="handbook-v02Product"></div>
+    <div id="v02Product"></div><div id="handbook-v02Product"></div>
     <h3>V0.2-V0.4 Grading</h3>
-    <div id="handbook-v02Grading"></div>
+    <div id="v02Grading"></div><div id="handbook-v02Grading"></div>
     <h3>V0.4 [release candidate] Additional Requirements</h3>
-    <div id="handbook-v04Product"></div>
+    <div id="v04Product"></div><div id="handbook-v04Product"></div>
     <h3>V0.5 [production release] Additional Requirements</h3>
-    <div id="handbook-v05Requirements"></div>
+    <div id="v05Requirements"></div><div id="handbook-v05Requirements"></div>
     <h3>V0.5 Submission</h3>
-    <div id="handbook-v05Submission"></div>
+    <div id="v05Submission"></div><div id="handbook-v05Submission"></div>
     <h3>V0.5 Demo and Q&A Session</h3>
-    <div id="handbook-v05Demo"></div>
+    <div id="v05Demo"></div><div id="handbook-v05Demo"></div>
     <h3>Project retrospective</h3>
-    <div id="handbook-projectRetrospective"></div>
+    <div id="projectRetrospective"></div><div id="handbook-projectRetrospective"></div>
     <h3>Individual report</h3>
-    <div id="handbook-individualReport"></div>
+    <div id="individualReport"></div><div id="handbook-individualReport"></div>
     <h3>V0.5 Evaluation</h3>
-    <div id="handbook-v05Evaluation"></div>
+    <div id="v05Evaluation"></div><div id="handbook-v05Evaluation"></div>
     <h2>Forming Teams</h2>
-    <div id="handbook-formingTeams"></div>
+    <div id="formingTeams"></div><div id="handbook-formingTeams"></div>
     <h2>Supervision</h2>
-    <div id="handbook-supervision"></div>
+    <div id="supervision"></div><div id="handbook-supervision"></div>
     <h2>Project Grading</h2>
-    <div id="handbook-projectGrading"></div>
+    <div id="projectGrading"></div><div id="handbook-projectGrading"></div>
     <h2>Peer Evaluations</h2>
-    <div id="handbook-peerEvaluations"></div>
+    <div id="peerEvaluations"></div><div id="handbook-peerEvaluations"></div>
     <h2>Project Tools</h2>
-    <div id="handbook-projectTools"></div>
+    <div id="projectTools"></div><div id="handbook-projectTools"></div>
     
     <h1>Exams</h1>
-    <div id="handbook-exams"></div>
+    <div id="exams"></div><div id="handbook-exams"></div>
     <h1>Grade Breakdown</h1>
-    <div id="handbook-gradeBreakdown"></div>
+    <div id="gradeBreakdown"></div><div id="handbook-gradeBreakdown"></div>
     <h1>Participation Points</h1>
-    <div id="handbook-participationPoints"></div>
+    <div id="participationPoints"></div><div id="handbook-participationPoints"></div>
 
     <h1>Appendix A: Module Principles</h1>
-    <div id="handbook-appendixA"></div>
+    <div id="appendixA"></div><div id="handbook-appendixA"></div>
 
     <h1>Appendix B: Module Policies</h1>
-    <div id="handbook-appendixB"></div>
+    <div id="appendixB"></div><div id="handbook-appendixB"></div>
     <h3>Policy on following instructions</h3>
-    <div id="handbook-policy-followingInstructions"></div>
+    <div id="policy-followingInstructions"></div><div id="handbook-policy-followingInstructions"></div>
     <h3>Policy on grading smaller/larger teams</h3>
-    <div id="handbook-policy-teamSize"></div>
+    <div id="policy-teamSize"></div><div id="handbook-policy-teamSize"></div>
     <h3>Policy on project work distribution</h3>
-    <div id="handbook-policy-workDistribution"></div>
+    <div id="policy-workDistribution"></div><div id="handbook-policy-workDistribution"></div>
     <h3>Policy on absence due to valid reasons (e.g. MC, LOA, University events)</h3>
-    <div id="handbook-policy-validAbsences"></div>
+    <div id="policy-validAbsences"></div><div id="handbook-policy-validAbsences"></div>
     <h3>Policy on email response time</h3>
-    <div id="handbook-policy-responseTime"></div>
+    <div id="policy-responseTime"></div><div id="handbook-policy-responseTime"></div>
     <h3>Policy on tech help</h3>
-    <div id="handbook-policy-techHelp"></div>
+    <div id="policy-techHelp"></div><div id="handbook-policy-techHelp"></div>
     <h3>Policy on publishing submissions</h3>
-    <div id="handbook-policy-publishingSubmissions"></div>
+    <div id="policy-publishingSubmissions"></div><div id="handbook-policy-publishingSubmissions"></div>
     <h3>Policy on plagiarism</h3>
-    <div id="handbook-policy-plagiarism"></div>
+    <div id="policy-plagiarism"></div><div id="handbook-policy-plagiarism"></div>
     <h3>Policy on reuse</h3>
-    <div id="handbook-policy-reuse"></div>
+    <div id="policy-reuse"></div><div id="handbook-policy-reuse"></div>
     <h3>Policy on help from outsiders</h3>
-    <div id="handbook-policy-outsiderHelp"></div>
+    <div id="policy-outsiderHelp"></div><div id="handbook-policy-outsiderHelp"></div>
     <h3>Policy on suggested length for submissions</h3>
-    <div id="handbook-policy-submissionLength"></div>
+    <div id="policy-submissionLength"></div><div id="handbook-policy-submissionLength"></div>
    
     <h1>Appendix C: Frequently Asked Questions</h1>
-    <div id="handbook-appendixC"></div>
+    <div id="appendixC"></div><div id="handbook-appendixC"></div>
     <h3>Why the workload is so high?</h3>
-    <div id="handbook-faq-highWorkload"></div>
+    <div id="faq-highWorkload"></div><div id="handbook-faq-highWorkload"></div>
     <h3>Why so much bean counting?</h3>
-    <div id="handbook-faq-beanCounting"></div>
+    <div id="faq-beanCounting"></div><div id="handbook-faq-beanCounting"></div>
     <h3>Why you force me to visit a separate website instead of using IVLE?</h3>
-    <div id="handbook-faq-separateWebsite"></div>
+    <div id="faq-separateWebsite"></div><div id="handbook-faq-separateWebsite"></div>
     <h3>Why slides are not detailed enough, handouts are wordy?</h3>
-    <div id="handbook-faq-slideFormat"></div>
+    <div id="faq-slideFormat"></div><div id="handbook-faq-slideFormat"></div>
     <h3>Why so much self-study?</h3>
-    <div id="handbook-faq-selfStudy"></div>
+    <div id="faq-selfStudy"></div><div id="handbook-faq-selfStudy"></div>
     <h3>Why do I have to come to tutorials on time?</h3>
-    <div id="handbook-faq-timelyArrival"></div>
+    <div id="faq-timelyArrival"></div><div id="handbook-faq-timelyArrival"></div>
     <h3>What if I don’t carry around a laptop?</h3>
-    <div id="handbook-faq-noLaptop"></div>
+    <div id="faq-noLaptop"></div><div id="handbook-faq-noLaptop"></div>
     <h3>Why very narrow project scope?</h3>
-    <div id="handbook-faq-narrowScope"></div>
+    <div id="faq-narrowScope"></div><div id="handbook-faq-narrowScope"></div>
     <h3>Why project requirements are so vague?</h3>
-    <div id="handbook-faq-vagueRequirements"></div>
+    <div id="faq-vagueRequirements"></div><div id="handbook-faq-vagueRequirements"></div>
     <h3>Why I’m not allowed to use my favorite OS/IDE/etc?</h3>
-    <div id="handbook-faq-favoriteTool"></div>
+    <div id="faq-favoriteTool"></div><div id="handbook-faq-favoriteTool"></div>
     <h3>Why so many submissions?</h3>
-    <div id="handbook-faq-manySubmissions"></div>
+    <div id="faq-manySubmissions"></div><div id="handbook-faq-manySubmissions"></div>
     <h3>Why not enough marks for intermediate submissions?</h3>
-    <div id="handbook-faq-intermediateMarks"></div>
+    <div id="faq-intermediateMarks"></div><div id="handbook-faq-intermediateMarks"></div>
     <h3>Why submission requirements differ between CS2103T and CS2101?</h3>
-    <div id="handbook-faq-cs2101Differences"></div>
+    <div id="faq-cs2101Differences"></div><div id="handbook-faq-cs2101Differences"></div>
     
     <h1>Appendix D: How to get tech help in CS2103/T</h1>
-    <div id="handbook-appendixD"></div>
+    <div id="appendixD"></div><div id="handbook-appendixD"></div>
    
     <h1>Appendix E: Using GitHub Project Hosting</h1>
-    <div id="handbook-appendixE"></div>
+    <div id="appendixE"></div><div id="handbook-appendixE"></div>
 
     <h1>Appendix F: What to do if there are teamwork issues</h1>
-    <div id="handbook-appendixF"></div>
+    <div id="appendixF"></div><div id="handbook-appendixF"></div>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.3/jquery-ui.min.js"></script>


### PR DESCRIPTION
Fixes #19 
It seems that the `handbook.js` interfered with how the links worked, since the links work fine without the js file, but I'm not sure what is causing that. 
I added empty divs with ids that don't overlap with those that the js is using, and it worked fine.
preview: http://crispyfridge.github.io/website/
