### PR TITLE
Scroll section into view when expanded #42

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -199,6 +199,15 @@ function loadContent(week) {
     });
 }
 
+function addAutoScrollToClickedSection() {
+ $(".buttoned").click(function (event){
+   var scroll_target = "#" + event.target.id;
+   $('html, body').animate({
+     scrollTop: $(scroll_target).offset().top
+ }, 1000);
+});
+}
+
 $(document).ready(function() {
 
     makeAccordion('.weeklyschedule');
@@ -220,6 +229,7 @@ $(document).ready(function() {
         loadContent(week);
     }
 
+    addAutoScrollToClickedSection();
     addCollapseAndExpandButtonsForAllContents("#form-preferences");
 
     // toggles showing/hiding certain sections according to the preferences checkbox

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -202,7 +202,6 @@ function loadContent(week) {
 function addAutoScrollToClickedWeekHeader() {
     $('.buttoned').click(function(event) {
         var scrollTarget = '#' + event.target.id;
-        console.log(scrollTarget);
         $('html, body').animate({
             scrollTop: $(scrollTarget).offset().top 
         }, 100);

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -199,12 +199,12 @@ function loadContent(week) {
     });
 }
 
-function addAutoScrollToClickedSection() {
-    $(".buttoned").click(function(event) {
-        var scroll_target = "#" + event.target.id;
+function addAutoScrollToClickedWeekHeader() {
+    $('.buttoned').click(function(event) {
+        var scrollTarget = '#' + event.target.id;
         $('html, body').animate({
-            scrollTop: $(scroll_target).offset().top 
-        }, 1000);
+            scrollTop: $(scrollTarget).offset().top 
+        }, 0);
     });
 }
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -200,12 +200,12 @@ function loadContent(week) {
 }
 
 function addAutoScrollToClickedSection() {
- $(".buttoned").click(function (event){
-   var scroll_target = "#" + event.target.id;
-   $('html, body').animate({
-     scrollTop: $(scroll_target).offset().top
- }, 1000);
-});
+    $(".buttoned").click(function(event) {
+        var scroll_target = "#" + event.target.id;
+        $('html, body').animate({
+            scrollTop: $(scroll_target).offset().top 
+        }, 1000);
+    });
 }
 
 $(document).ready(function() {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -202,6 +202,7 @@ function loadContent(week) {
 function addAutoScrollToClickedWeekHeader() {
     $('.buttoned').click(function(event) {
         var scrollTarget = '#' + event.target.id;
+        console.log(scrollTarget);
         $('html, body').animate({
             scrollTop: $(scrollTarget).offset().top 
         }, 0);
@@ -229,7 +230,7 @@ $(document).ready(function() {
         loadContent(week);
     }
 
-    addAutoScrollToClickedSection();
+    addAutoScrollToClickedWeekHeader();
     addCollapseAndExpandButtonsForAllContents("#form-preferences");
 
     // toggles showing/hiding certain sections according to the preferences checkbox

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -205,7 +205,7 @@ function addAutoScrollToClickedWeekHeader() {
         console.log(scrollTarget);
         $('html, body').animate({
             scrollTop: $(scrollTarget).offset().top 
-        }, 0);
+        }, 100);
     });
 }
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -204,7 +204,7 @@ function addAutoScrollToClickedWeekHeader() {
         var scrollTarget = '#' + event.currentTarget.id;
         $('html, body').animate({
             scrollTop: $(scrollTarget).offset().top 
-        }, 100);
+        }, 500);
     });
 }
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -201,7 +201,7 @@ function loadContent(week) {
 
 function addAutoScrollToClickedWeekHeader() {
     $('.buttoned').click(function(event) {
-        var scrollTarget = '#' + event.target.id;
+        var scrollTarget = '#' + event.currentTarget.id;
         $('html, body').animate({
             scrollTop: $(scrollTarget).offset().top 
         }, 100);


### PR DESCRIPTION
Fixes #42 and supersedes closed PR #122 

Staged version can be viewed <a href = "http://jkt001.github.io/website">here</a>.

Currently, the fix is to scroll to a "week section" and not to inner sections since I assume that people would most likely scroll into a specific week and read the contents inside. 

If this is not the expected behaviour, I would update this PR in subsequent commits.