### PR TITLE
Typo in contents/handbook.html #131

### DIFF
--- a/contents/handbook.html
+++ b/contents/handbook.html
@@ -34,7 +34,7 @@
         <li><a href="#handbook-theProduct">The product</a></li>
         <li><a href="#handbook-projectScope">Project Scope</a></li>
         <li><a href="#handbook-projectConstraints">Project Constraints</a></li>
-        <li><a href="#handbook-deliveables">Deliverables</a></li>
+        <li><a href="#handbook-deliverables">Deliverables</a></li>
         <ul>
             <li><a href="#handbook-ce1">CE1: TextBuddy</a></li>
             <li><a href="#handbook-ce2">CE2: TextBuddy++</a></li>
@@ -122,7 +122,7 @@
     <h2>Project Constraints</h2>
     <div id="handbook-projectConstraints" ></div>
     <h2>Deliverables</h2>
-    <div id="handbook-deliveables" ></div>
+    <div id="handbook-deliverables" ></div>
 
     <h3>CE1: TextBuddy</h3>
     <div id="handbook-ce1"></div>
@@ -257,7 +257,7 @@
         'handbook-theProduct',
         'handbook-projectScope',
         'handbook-projectConstraints',
-        'handbook-deliveables',
+        'handbook-deliverables',
         'handbook-ce1',
         'handbook-ce2',
         'handbook-ce3',


### PR DESCRIPTION
Fixes #131 

This is a quick fix to the critical typo in handbook.html. The deliverables part of the handbook should be visible now. 

Staged version is <a href = "http://jkt001.github.io/website/">here</a>.