### PR TITLE
Handbook: instructions about the handout is incorrect #116

### DIFF
--- a/contents/handbook-lectures.html
+++ b/contents/handbook-lectures.html
@@ -36,8 +36,8 @@
     Please treat the webcast as a 'backup' for you to catch up anything missed during the lecture.
 </p>
 <p>
-    <strong>Handouts</strong>: Each lecture consists of 1-3 sections, supported by separate handouts. 
-    These handouts will be uploaded to the module website (see the 'Schedule' page) by Wednesday midnight of the same week. 
+    <strong>Handouts</strong>: Each lecture consists of 1-3 sections, supported by separate handouts.
+    The full handbook containing all the sections is uploaded to IVLE workbin at the beginning of the semester.
     You are welcome to, but not required to, read through them before attending the lecture.
 </p>
 <p>


### PR DESCRIPTION
Fixes: #116 
Here is a preview: http://harishv7.github.io/website-1/

New description: Each lecture consists of 1-3 sections, supported by
separate handouts. The full handbook containing all the sections is
uploaded to IVLE workbin at the beginning of the semester.
You are welcome to, but not required to, read through them before
attending the lecture.