### PR TITLE
Issue #145: Fixed typo 'exract' in common.js, changed to 'extract'

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -21,7 +21,7 @@ function makeAccordion(elementSelector) {
 }
 
 function getContentUsingAjax(fileName, elementSelector, sectionName) {
-    pullContent(fileName, elementSelector, 'Exract from handbook', sectionName);
+    pullContent(fileName, elementSelector, 'Extract from handbook', sectionName);
 }
 
 function pullContent(fileName, elementSelector, title, sectionName) {


### PR DESCRIPTION
In function getContentUsingAjax in the file Common.js, there was a typo 'Exract from handbook', which affects all the embedded handbook links.

Fixed by changing to `Extract from handbook`.
