### PR TITLE
Refactor load content in context

### DIFF
--- a/contents/week1.html
+++ b/contents/week1.html
@@ -38,10 +38,10 @@
                 <b>Handbook sections to read around this time:</b>
                 <ul>
                     <li>
-                        General: <span onclick="getContentUsingAjax('handbook-preliminaries', '#embedded-week1-general');"><span class="embedded-link">Preliminaries</span></span> | 
-                                 <span onclick="getContentUsingAjax('handbook-textBooks', '#embedded-week1-general');"><span class="embedded-link">Text Books</span></span> | 
-                                 <span onclick="getContentUsingAjax('handbook-programmingLanguages', '#embedded-week1-general');"><span class="embedded-link">Programming Language</span></span> | 
-                                 <span onclick="getContentUsingAjax('handbook-appendixA', '#embedded-week1-general');"><span class="embedded-link">Module Principles</span></span>
+                        General: <span class="embedded-link" data-url="handbook-preliminaries.html" data-id="#embedded-week1-general">Preliminaries</span> | 
+                                 <span class="embedded-link" data-url="handbook-textBooks.html" data-id="#embedded-week1-general">Text Books</span> | 
+                                 <span class="embedded-link" data-url="handbook-programmingLanguages.html" data-id="#embedded-week1-general">Programming Language</span> | 
+                                 <span class="embedded-link" data-url="handbook-appendixA.html" data-id="#embedded-week1-general">Module Principles</span>
                                  <div id="embedded-week1-general"></div>
                     </li>
                     <li>

--- a/contents/week1.html
+++ b/contents/week1.html
@@ -37,25 +37,22 @@
                 If you don't feel like reading everything in it (it contains a lot of text), at least skim through the headings to know what is in there. You can go back and read the details as and when you need them.<br>
                 <b>Handbook sections to read around this time:</b>
                 <ul>
-                    <li>
-                        General: <span class="embedded-link" data-url="handbook-preliminaries.html" data-id="#embedded-week1-general">Preliminaries</span> | 
-                                 <span class="embedded-link" data-url="handbook-textBooks.html" data-id="#embedded-week1-general">Text Books</span> | 
-                                 <span class="embedded-link" data-url="handbook-programmingLanguages.html" data-id="#embedded-week1-general">Programming Language</span> | 
-                                 <span class="embedded-link" data-url="handbook-appendixA.html" data-id="#embedded-week1-general">Module Principles</span>
-                                 <div id="embedded-week1-general"></div>
+                    <li class="embedded-link-bar">
+                        General: <span class="embedded-link" data-url="handbook-preliminaries.html">Preliminaries</span> | 
+                                 <span class="embedded-link" data-url="handbook-textBooks.html">Text Books</span> | 
+                                 <span class="embedded-link" data-url="handbook-programmingLanguages.html">Programming Language</span> | 
+                                 <span class="embedded-link" data-url="handbook-appendixA.html">Module Principles</span>
                     </li>
-                    <li>
-                        Project: <span onclick="getContentUsingAjax('handbook-theProduct', '#embedded-week1-project');"><span class="embedded-link">The Product</span></span> | 
-                                 <span onclick="getContentUsingAjax('handbook-projectScope', '#embedded-week1-project');"><span class="embedded-link">Project Scope</span></span> |
-                                 <span onclick="getContentUsingAjax('handbook-projectConstraints', '#embedded-week1-project');"><span class="embedded-link">Project Constraints</span></span> |
-                                 <span onclick="getContentUsingAjax('handbook-deliverables', '#embedded-week1-project');"><span class="embedded-link">Deliverables</span></span>
-                                 <div id="embedded-week1-project"></div>
+                    <li class="embedded-link-bar">
+                        Project: <span class="embedded-link" data-url="handbook-theProduct.html">The Product</span> | 
+                                 <span class="embedded-link" data-url="handbook-projectScope.html">Project Scope</span> |
+                                 <span class="embedded-link" data-url="handbook-projectConstraints.html">Project Constraints</span> |
+                                 <span class="embedded-link" data-url="handbook-deliverables.html">Deliverables</span>
                     </li>
-                    <li>
-                        FAQ: <span onclick="getContentUsingAjax('handbook-faq-highWorkload', '#embedded-week1-faqs');"><span class="embedded-link">Why the workload is so high?</span></span> |
-                             <span onclick="getContentUsingAjax('handbook-faq-beanCounting', '#embedded-week1-faqs');"><span class="embedded-link">Why so much bean counting?</span></span> |
-                             <span onclick="getContentUsingAjax('handbook-faq-separateWebsite', '#embedded-week1-faqs');"><span class="embedded-link">Why you force me to visit a separate website instead of using IVLE?</span></span>
-                             <div id="embedded-week1-faqs"></div>
+                    <li class="embedded-link-bar">
+                        FAQ: <span class="embedded-link" data-url="handbook-faq-highWorkload.html">Why the workload is so high?</span> |
+                             <span class="embedded-link" data-url="handbook-faq-beanCounting.html">Why so much bean counting?</span> |
+                             <span class="embedded-link" data-url="handbook-faq-separateWebsite.html">Why you force me to visit a separate website instead of using IVLE?</span>
                     </li>
                 </ul>
             </div>
@@ -71,10 +68,8 @@
         </div>
         <div class="things-to-do things-to-do-week1">
             <h3>Attend Lecture 1 <span class="highlighted-darktext">(compulsory)</span></h3>
-            <div>
-                <span onclick="getContentUsingAjax('handbook-lectures', '#embedded-week1-lectures');"><span class="embedded-link">More about lectures</span></span>
-                <div id="embedded-week1-lectures">
-                </div>
+            <div class="embedded-link-bar">
+                <span class="embedded-link" data-url="handbook-lectures.html">More about lectures</span>
             </div>
         </div>
         <div class="things-to-do things-to-do-week1">

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -20,22 +20,21 @@ function makeAccordion(elementSelector) {
     });
 }
 
-function getContentUsingAjax(fileName, elementSelector, sectionName) {
-    pullContent(fileName, elementSelector, 'Exract from handbook', sectionName);
-}
-
-function pullContent(fileName, elementSelector, title, sectionName) {
-    var toBeLoaded = fileName + '.html' + (sectionName == undefined ? '' : ' #' + sectionName);
-    $(elementSelector).html('<img class="embedded-link-loading-img" src="../images/ajax-preload.gif" alt="Loading...">');
-    $(elementSelector).load(toBeLoaded, function(response, status, xhr) {
+function pullContent(link) {
+    var url = link.data('url');
+    var modal = link.data('id');
+    console.log(url);
+    console.log(modal);
+    $(modal).html('<img class="embedded-link-loading-img" src="../images/ajax-preload.gif" alt="Loading...">');
+    $(modal).load(url, function(response, status, xhr) {
         if (status == 'success') {
-            $(elementSelector).addClass('embedded');
-            $(elementSelector).prepend('<div><span class="embeddedHeading">' + title + '</span><button onclick="$(\'' + elementSelector + '\').html(\'\');' +
-               ' $(\'' + elementSelector + '\').removeClass(\'embedded\');" ' +
+            $(modal).addClass('embedded');
+            $(modal).prepend('<div><span class="embeddedHeading">' + 'Extract from handbook' + '</span><button onclick="$(\'' + modal + '\').html(\'\');' +
+               ' $(\'' + modal + '\').removeClass(\'embedded\');" ' +
                'class="btn-dismiss">X</button><br><br></div>');
-            $(elementSelector + ' > div > .btn-dismiss').button();
+            $(modal + ' > div > .btn-dismiss').button();
         }
-    }); 
+    });
 }
 
 function addCollapseAndExpandButtonsForComponents(accordionHeaderSelector, divId) {
@@ -333,5 +332,9 @@ $(document).ready(function() {
             }
         }
     });
+
+    $(document).on('click', '.embedded-link', function() {
+        pullContent($(this));
+    })
 
 });

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -20,20 +20,54 @@ function makeAccordion(elementSelector) {
     });
 }
 
-function pullContent(link) {
+function getContentUsingAjax(fileName, elementSelector, sectionName) {
+    pullContent(fileName, elementSelector, 'Exract from handbook', sectionName);
+}
+
+function pullContent(fileName, elementSelector, title, sectionName) {
+    var toBeLoaded = fileName + '.html' + (sectionName == undefined ? '' : ' #' + sectionName);
+    $(elementSelector).html('<img class="embedded-link-loading-img" src="../images/ajax-preload.gif" alt="Loading...">');
+    $(elementSelector).load(toBeLoaded, function(response, status, xhr) {
+        if (status == 'success') {
+            $(elementSelector).addClass('embedded');
+            $(elementSelector).prepend('<div><span class="embeddedHeading">' + title + '</span><button onclick="$(\'' + elementSelector + '\').html(\'\');' +
+               ' $(\'' + elementSelector + '\').removeClass(\'embedded\');" ' +
+               'class="btn-dismiss">X</button><br><br></div>');
+            $(elementSelector + ' > div > .btn-dismiss').button();
+        }
+    }); 
+}
+
+function showContent(modal, link) {
     var url = link.data('url');
-    var modal = link.data('id');
-    console.log(url);
-    console.log(modal);
     $(modal).html('<img class="embedded-link-loading-img" src="../images/ajax-preload.gif" alt="Loading...">');
     $(modal).load(url, function(response, status, xhr) {
         if (status == 'success') {
             $(modal).addClass('embedded');
-            $(modal).prepend('<div><span class="embeddedHeading">' + 'Extract from handbook' + '</span><button onclick="$(\'' + modal + '\').html(\'\');' +
-               ' $(\'' + modal + '\').removeClass(\'embedded\');" ' +
-               'class="btn-dismiss">X</button><br><br></div>');
-            $(modal + ' > div > .btn-dismiss').button();
+            $(modal).prepend('<div><span class="embeddedHeading">Extract from handbook</span><button class="btn-dismiss">x</button><br><br></div>');
         }
+    });
+}
+
+function closeContent(modal) {
+    $(modal).html('');
+    $(modal).removeClass('embedded');
+}
+
+function addEmbeddedLinkBarModal(elementSelector) {
+    $(elementSelector).find('.embedded-link-bar').each(function(i, embeddedLinkBar) {
+        embeddedLinkBar = $(embeddedLinkBar);
+
+        var modal = $("<div></div>");
+        embeddedLinkBar.append(modal);
+
+        embeddedLinkBar.on('click', '.embedded-link', function() {
+            showContent(modal, $(this));
+        })
+
+        embeddedLinkBar.on('click', '.btn-dismiss', function() {
+            closeContent(modal);
+        })
     });
 }
 
@@ -210,6 +244,7 @@ function loadContent(week) {
                     $('.' + type + '.content-week' + week).hide();
                 }
             });
+            addEmbeddedLinkBarModal($('#content-week' + week));
         }
     });
 }
@@ -332,9 +367,4 @@ $(document).ready(function() {
             }
         }
     });
-
-    $(document).on('click', '.embedded-link', function() {
-        pullContent($(this));
-    })
-
 });


### PR DESCRIPTION
Removed inline JS to make code more readable and reusable

addEmbeddedLinkBarModal() in common.js appends an empty div (i.e. <div></div>) to each embedded-link-bar, replacing the need for an empty div (i.e. <div id="embedded-week1-general"></div>) in the html files.

Refactoring is only applied to week1.html for demonstration. Will apply to the rest if approach is ok!

Here is a [preview](http://anaprimawaty.github.io/website/)