### PR TITLE
(Leaderboard) Need to keep scrolling to see Table Header row #40

### DIFF
--- a/contents/leaderboard.html
+++ b/contents/leaderboard.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Leaderboard - CS2103/T</title>
+</head>
+<body>
+</body>
+</html>

--- a/contents/leaderboard.html
+++ b/contents/leaderboard.html
@@ -4,7 +4,30 @@
   <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Leaderboard - CS2103/T</title>
+  <style>
+    .leaderboard {
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+    #leaderboard-data {
+        height: 100%;
+        width: 100%;
+        font-size: 0;
+    }
+    .leaderboard-iframe {
+        width: 5500px;
+        border: none;
+    }
+    #leaderboard-data-iframe {
+        height: 100%;
+    }
+  </style>
 </head>
 <body>
+  <div class="leaderboard" id="leaderboard-data">
+    <iframe class="leaderboard-iframe" id="leaderboard-data-iframe"
+     src="https://docs.google.com/spreadsheets/d/1OD_SPNX8QeDO25kj8JQc7zvd7acxI16hyXhdGncRWvI/pubhtml"></iframe>
+  </div>
 </body>
 </html>

--- a/contents/leaderboard.html
+++ b/contents/leaderboard.html
@@ -15,6 +15,11 @@
         width: 100%;
         font-size: 0;
     }
+    #leaderboard-header {
+        height: 100px;
+        width: 5500px;
+        overflow: hidden;
+    }
     .leaderboard-iframe {
         width: 5500px;
         border: none;
@@ -22,11 +27,18 @@
     #leaderboard-data-iframe {
         height: 100%;
     }
+    #leaderboard-header-iframe {
+        height: 5100px;
+    }
   </style>
 </head>
 <body>
   <div class="leaderboard" id="leaderboard-data">
     <iframe class="leaderboard-iframe" id="leaderboard-data-iframe"
+     src="https://docs.google.com/spreadsheets/d/1OD_SPNX8QeDO25kj8JQc7zvd7acxI16hyXhdGncRWvI/pubhtml"></iframe>
+  </div>
+  <div class="leaderboard" id="leaderboard-header">
+    <iframe class="leaderboard-iframe" id="leaderboard-header-iframe"
      src="https://docs.google.com/spreadsheets/d/1OD_SPNX8QeDO25kj8JQc7zvd7acxI16hyXhdGncRWvI/pubhtml"></iframe>
   </div>
 </body>

--- a/contents/leaderboard.html
+++ b/contents/leaderboard.html
@@ -31,6 +31,7 @@
         height: 5100px;
     }
   </style>
+  <script type="text/javascript" href="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 </head>
 <body>
   <div class="leaderboard" id="leaderboard-data">
@@ -41,5 +42,12 @@
     <iframe class="leaderboard-iframe" id="leaderboard-header-iframe"
      src="https://docs.google.com/spreadsheets/d/1OD_SPNX8QeDO25kj8JQc7zvd7acxI16hyXhdGncRWvI/pubhtml"></iframe>
   </div>
+  <script>
+    $(document).ready(function() {
+      $('#leaderboard-data').scroll(function() {
+        $('#leaderboard-header').scrollLeft($(this).scrollLeft());
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #40
[Preview](https://rawgit.com/acjh/website/21-show-leaderboard-link/index.html) (available as [standalone](https://rawgit.com/acjh/website/21-show-leaderboard-link/contents/leaderboard.html)) vs [Previous](http://www.comp.nus.edu.sg/~cs2103/AY1516S1/)
Note: Click on `Leaderboard` link in headings!

---

Challenges of an alternative implementation that uses Javascript to load and manipulate html directly:
- Cross-domain ajax (blocked by JavaScript) requires workarounds, but this is relatively easy to solve
- Google Docs CSS and JavaScript do not work as expected when `$('#container').html('new_html')`
- _Very twisted_ Jquery required to manipulate the frames and still cannot achieve close enough quality

---

PS: The last commit on `gh-pages` (`Show leaderboard link`) was not pushed to this fix; headings are safe :)
