### PR TITLE
Syntax highlighting on the unit testing FAQ page makes the code illegible #194

### DIFF
--- a/styles/common.css
+++ b/styles/common.css
@@ -88,10 +88,13 @@ a:visited {
   padding-left:4em;
 }
 
-code{
+:not(pre) > code {
+    background-color: #f2f2f2;
+}
+
+code {
     font-family: courier;
     font-size: small;
-    background-color: #f2f2f2;
 }
 
 .shell{


### PR DESCRIPTION
This prevents the CSS background color for `code` leaking into the sunburst prettifier theme.

This fixes #194

![screen shot 2016-11-25 at 3 08 44 pm](https://cloud.githubusercontent.com/assets/2093506/20616997/155f89ae-b321-11e6-8721-16d503bff44a.png)
