### PR TITLE
Typo in common.js #145

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -21,7 +21,7 @@ function makeAccordion(elementSelector) {
 }
 
 function getContentUsingAjax(fileName, elementSelector, sectionName) {
-    pullContent(fileName, elementSelector, 'Exract from handbook', sectionName);
+    pullContent(fileName, elementSelector, 'Extract from handbook', sectionName);
 }
 
 function pullContent(fileName, elementSelector, title, sectionName) {


### PR DESCRIPTION
Fixes #145 

Fixed the typo in common.js that renders the button "Extract from handbook" for entire website.