### PR TITLE
Fix size and position of 'Page Loading...' overlay in handbook page #112

### DIFF
--- a/contents/handbook.html
+++ b/contents/handbook.html
@@ -12,8 +12,7 @@
 </head>
 <body>
 
-<div id="overlay"></div>
-<div id="modal">Page Loading...</div>
+<div id="overlay">Page Loading...</div>
 <div id="back-to-top-button">Back To Top</div>
 <div id="table-of-contents">
   <ul>

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -11,7 +11,6 @@ setTimeout(function () {
                 $('#' + section).html(data);
                 var isLastSection = (i == sections.length-1);
                 if (isLastSection) {
-                    $('#modal').remove();
                     $('#overlay').remove();
                 }
             }

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -9,13 +9,10 @@ setTimeout(function () {
             },
             success: function(data) {
                 $('#' + section).html(data);
-                var isLastSection = (i == sections.length-1);
-                if (isLastSection) {
-                    $('#overlay').remove();
-                }
             }
         });
     }
+    $('#overlay').remove();
 }, 0);
 
 function isTableOfContentVisible() {

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -9,12 +9,15 @@ setTimeout(function () {
             },
             success: function(data) {
                 $('#' + section).html(data);
+                var isLastSection = (i == sections.length-1);
+                if (isLastSection) {
+                    $('#modal').remove();
+                    $('#overlay').remove();
+                }
             }
         });
     }
 }, 0);
-$('#modal').remove();
-$('#overlay').remove();
 
 function isTableOfContentVisible() {
     var windowTop = $(window).scrollTop();

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -1,16 +1,18 @@
-for (var i in sections) {
-    var section = sections[i];
-    $.ajax({
-        type: 'GET',
-        async: false,
-        url: section + '.html',
-        error: function() {
-        },
-        success: function(data) {
-            $('#' + section).html(data);
-        }
-    });
-}
+setTimeout(function () {
+    for (var i in sections) {
+        var section = sections[i];
+        $.ajax({
+            type: 'GET',
+            async: false,
+            url: section + '.html',
+            error: function() {
+            },
+            success: function(data) {
+                $('#' + section).html(data);
+            }
+        });
+    }
+}, 0);
 $('#modal').remove();
 $('#overlay').remove();
 

--- a/styles/common.css
+++ b/styles/common.css
@@ -47,30 +47,18 @@ a:visited {
 }
 
 #overlay {
-    position: absolute;
-    top: 37%;
-    left: 39.5%;
     width: 20%;
-    height: 20%;
     background-color: rgba(0,0,0,0.5);
     border-radius: 5px;
-    z-index: 10;
-}
-
-#modal {
-    width: 150px;
-    height: 25px;
     line-height: 50px;
     position: fixed;
-    top: 50%; 
+    top: 50%;
     left: 50%;
-    margin-top: -50px;
-    margin-left: -75px;
     text-align: center;
     font-size: large;
     font-family: sans-serif;
     color: #ffffff;
-    z-index: 11; /* 1px higher than the overlay layer */
+    transform: translate(-50%, -50%);
 }
 
 .embedded-link-loading-img {

--- a/styles/common.css
+++ b/styles/common.css
@@ -46,21 +46,6 @@ a:visited {
     overflow-y: auto;
 }
 
-#overlay {
-    width: 20%;
-    background-color: rgba(0,0,0,0.5);
-    border-radius: 5px;
-    line-height: 50px;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    text-align: center;
-    font-size: large;
-    font-family: sans-serif;
-    color: #ffffff;
-    transform: translate(-50%, -50%);
-}
-
 .embedded-link-loading-img {
     height: 50px;
     width: 50px;
@@ -443,10 +428,6 @@ img {
 @media screen and (max-device-width: 1000px) {
     body{
         max-width: 100%;
-    }
-
-    #overlay {
-        width: 50%;
     }
 }
 

--- a/styles/common.css
+++ b/styles/common.css
@@ -444,6 +444,10 @@ img {
     body{
         max-width: 100%;
     }
+
+    #overlay {
+        width: 50%;
+    }
 }
 
 /* For any device whose view is 500px or below */

--- a/styles/handbook.css
+++ b/styles/handbook.css
@@ -46,6 +46,10 @@ img {
 	body{
 		max-width: 100%;
 	}
+
+    #overlay {
+        width: 50%;
+    }
 }
 
 #back-to-top-button{
@@ -63,4 +67,19 @@ img {
 #back-to-top-button:hover{
 	color: #3c763d;
 	background: #dff0d8;
+}
+
+#overlay {
+    width: 20%;
+    background-color: rgba(0,0,0,0.5);
+    border-radius: 5px;
+    line-height: 50px;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    text-align: center;
+    font-size: large;
+    font-family: sans-serif;
+    color: #ffffff;
+    transform: translate(-50%, -50%);
 }

--- a/styles/handbook.css
+++ b/styles/handbook.css
@@ -40,18 +40,6 @@ img {
 	height: auto;
 }
 
-/* 740px since max-width of body is set to 740px
-   Any device whose view is below 740px will use this*/
-@media screen and (max-device-width: 740px) {
-	body{
-		max-width: 100%;
-	}
-
-    #overlay {
-        width: 50%;
-    }
-}
-
 #back-to-top-button{
 	display: none;
 	position: fixed;
@@ -82,4 +70,16 @@ img {
     font-family: sans-serif;
     color: #ffffff;
     transform: translate(-50%, -50%);
+}
+
+/* 740px since max-width of body is set to 740px
+   Any device whose view is below 740px will use this*/
+@media screen and (max-device-width: 740px) {
+    body{
+        max-width: 100%;
+    }
+
+    #overlay {
+        width: 50%;
+    }
 }


### PR DESCRIPTION
Fixes #112
[Preview](http://rawgit.com/acjh/website/112-fix-loading-overlay-handbook/)

1. **Fixed overlay not appearing**
I noticed that `handbook.html` was blocking UI updates while it was loading into the `content` frame.
After implementing this fix using `setTimeout`, I found [this explanation for its use](http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful#779785) on Stack Overflow.

2. **Fixed size and position of overlay (on mobile)**

| Before | After |
| --- | --- |
| <img src="https://cloud.githubusercontent.com/assets/14091939/21026461/a56177fa-bdc7-11e6-8db7-0b26482abd45.png" width="300"> | <img src="https://cloud.githubusercontent.com/assets/14091939/21026503/e24435b8-bdc7-11e6-9a52-5c887ae43170.png" width="300"> |