### PR TITLE
Make page fragments previewable #89

### DIFF
--- a/contents/week.html
+++ b/contents/week.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>[Aug16] Schedule - CS2103/T</title>
+        <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.3/jquery-ui.min.css" />
+        <link type="text/css" rel="stylesheet" href="../styles/common.css" />
+    </head>
+    <body>
+        <div id="content">
+            <div class="weeklyschedule">
+                <h3 id="header-content-week" class="buttoned"><span></span></h3>
+                <div id="content-week">
+                </div>
+            </div>
+        <div>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.3/jquery-ui.min.js"></script>
+        <script>
+            var preview = window.location.href.match(/\?preview=([^&#]*)/);
+            var week = preview[1];
+            $('h3').attr('id', 'header-content-week' + week);
+            $('span').html('Week ' + week + ' [<span class="date-marker" week="' + week + '" day="1"></span>]');
+            $('#content-week').attr('id', 'content-week' + week);
+        </script>
+        <script type="text/javascript" src="../scripts/common.js"></script>
+    </body>
+</html>

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -215,6 +215,10 @@ function loadContent(week) {
                     $('.' + type + '.content-week' + week).hide();
                 }
             });
+
+            if (typeof preview != 'undefined') {
+                $('#expandall-content-week' + week).click();
+            }
         }
     });
 }

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -2,9 +2,7 @@ var preview = window.location.href.match(/\?preview=([^&#]*)/);
 if (preview != null) {
     var section = 'handbook-' + preview[1];
     sections = [section];
-    $('#table-of-contents').html('');
-    $('#' + section).prev().prevUntil('#table-of-contents').remove();
-    $('#' + section).nextUntil('script').remove();
+    $(window).scrollTop($('#' + section).prev().offset().top);
 }
 
 setTimeout(function () {

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -1,3 +1,12 @@
+var preview = window.location.href.match(/\?preview=([^&#]*)/);
+if (preview != null) {
+    var section = 'handbook-' + preview[1];
+    sections = [section];
+    $('#table-of-contents').html('');
+    $('#' + section).prev().prevUntil('#table-of-contents').remove();
+    $('#' + section).nextUntil('script').remove();
+}
+
 setTimeout(function () {
     for (var i in sections) {
         var section = sections[i];


### PR DESCRIPTION
Fixes #89. Took a different approach from PR #118 for maintainability.

Preview 1: [`.../contents/week.html?preview=1`](http://rawgit.com/acjh/website/89-make-page-fragments-previewable/contents/week.html?preview=1)
> `preview` can be any of [weeks](https://github.com/nus-cs2103/website/blob/master/contents/schedule.html#L31) `0`-`14`

Preview 2: [`.../contents/handbook.html?preview=preliminaries`](http://rawgit.com/acjh/website/89-make-page-fragments-previewable/contents/handbook.html?preview=preliminaries)
> `preview` can be any of [these sections](https://github.com/acjh/website/blob/89-make-page-fragments-previewable/contents/handbook.html#L181), **without** the `handbook-` prefix:
>&nbsp;
`var sections = [`
`        'handbook-preliminaries',`
`        'handbook-lectures',`
`        'handbook-tutorials',`
`        'handbook-textBooks',`
`        'handbook-programmingLanguages',`
`        'handbook-project',`
`        'handbook-project-product',`
`        'handbook-project-scope',`
`        'handbook-project-constraints',`
`        'handbook-project-deliverables',`
`        'handbook-project-v00',`
`        'handbook-project-v01',`
`        'handbook-project-v02',`
`        'handbook-project-v03',`
`        'handbook-project-v04',`
`        'handbook-project-v05rc',`
`        'handbook-project-v05',`
`        'handbook-project-retrospective',`
`        'handbook-project-individualReport',`
`        'handbook-project-assessment',`
`        'handbook-project-supervision',`
`        'handbook-teams',`
`        'handbook-peerEvaluations',`
`        'handbook-tools',`
`        'handbook-exams',`
`        'handbook-gradeBreakdown',`
`        'handbook-participation',`
`        'handbook-appendixA-principles',`
`        'handbook-appendixB-policies',`
`        'handbook-policy',`
`        'handbook-appendixC-faq',`
`        'handbook-appendixD-help',`
`        'handbook-appendixE-github',`
`        'handbook-appendixF-teamworkIssues'];`