### PR TITLE
Code with black text is hidden on black background #211

### DIFF
--- a/contents/handbook.html
+++ b/contents/handbook.html
@@ -216,6 +216,10 @@
 </script>
 <p>-------------------------------------End of document----------------------------------------</p>
 <script type="text/javascript" src="../scripts/handbook.js"></script>
-<script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?skin=sunburst"></script>
+<script>
+    $(document).ready(function() {
+        $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?skin=sunburst");
+    });
+</script>
 </body>
 </html>

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -126,7 +126,11 @@ function isTableOfContentVisible() {
     return windowTop < tableBottom;
 }
 
-$(document).ready(function() {
+/**
+ * Loads sections based on whether preview has been requested.
+ * If not preview, hold $(document).ready until ajax callback.
+ */
+function loadSectionsBeforeDocumentReady() {
     var preview = window.location.href.match(/\?preview=([^&#]*)/);
 
     if (preview) {
@@ -145,7 +149,11 @@ $(document).ready(function() {
         loadAllSectionsUsingAjax(callback);
         addJumpToSectionHeadingBehavior($('a'));
     }
+}
 
+loadSectionsBeforeDocumentReady();
+
+$(document).ready(function() {
     var buttonAnimationDuration = 200;
     var speed = 1;
 

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -105,14 +105,14 @@ function loadSectionUsingAjax(section, callback) {
  * Increment number of sections loaded in callback.
  * If all sections loaded, remove the loading overlay.
  */
-function loadAllSections() {
+function loadAllSectionsUsingAjax(callbackOnLoadAll) {
     var sectionsLoaded = 0;
     for (var i in sections) {
         var section = sections[i];
         var callback = function() {
             sectionsLoaded++;
             if (sectionsLoaded == sections.length) {
-                $('#overlay').remove();
+                callbackOnLoadAll();
             }
         };
         loadSectionUsingAjax(section, callback);
@@ -139,7 +139,10 @@ $(document).ready(function() {
         $('a[href="#' + section + '"]').click();
         $('#overlay').remove();
     } else {
-        loadAllSections();
+        var callback = function() {
+            $('#overlay').remove();
+        }
+        loadAllSectionsUsingAjax(callback);
         addJumpToSectionHeadingBehavior($('a'));
     }
 

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -143,7 +143,9 @@ function loadSectionsBeforeDocumentReady() {
         $('a[href="#' + section + '"]').click();
         $('#overlay').remove();
     } else {
+        $.holdReady(true);
         var callback = function() {
+            $.holdReady(false);
             $('#overlay').remove();
         }
         loadAllSectionsUsingAjax(callback);


### PR DESCRIPTION
Fixes #211
[Preview](http://rawgit.com/acjh/website/211-code-black-text-hidden/contents/handbook.html)

Uses `$.holdReady` in `handbook.js` before `run_prettify.js` is loaded.