### PR TITLE
Auto-expand the current week of the schedule page #33

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -218,6 +218,8 @@ function loadContent(week) {
 
             if (typeof preview != 'undefined') {
                 expandWeekFully(week);
+            } else if (isCurrentWeek(week)) {
+                expandWeekFully(week);
             }
         }
     });
@@ -350,6 +352,16 @@ function getDate(week, day) {
     var daysPassed = weeksPassed * 7 + day - 1;
     date.setTime(MODULE_START_DATE.getTime() + daysPassed * MILLI_SECS_PER_DAY);
     return date;
+}
+
+/**
+ * Determines if a given week is the current week.
+ * Uses the ISO 8601 week, which starts on Monday.
+ */
+function isCurrentWeek(week) {
+    var weekOfYear = $.datepicker.iso8601Week(getDate(week, 1));
+    var currentWeekOfYear = $.datepicker.iso8601Week(new Date());
+    return weekOfYear == currentWeekOfYear;
 }
 
 /**

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -217,7 +217,7 @@ function loadContent(week) {
             });
 
             if (typeof preview != 'undefined') {
-                $('#expandall-content-week' + week).click();
+                expandWeekFully(week);
             }
         }
     });
@@ -350,6 +350,13 @@ function getDate(week, day) {
     var daysPassed = weeksPassed * 7 + day - 1;
     date.setTime(MODULE_START_DATE.getTime() + daysPassed * MILLI_SECS_PER_DAY);
     return date;
+}
+
+/**
+ * Expands a week fully, by clicking its expand all button.
+ */
+function expandWeekFully(week) {
+    $("#expandall-content-week" + week).click();
 }
 
 function addAutoScrollToClickedWeekHeader() {


### PR DESCRIPTION
Fixes #33 
[Preview](http://rawgit.com/acjh/website/33-auto-expand-current-week/)

Note: The commit ef5f608 offsets today by `-6` weeks (i.e. sets the *current* week to Week 12).
It's as minimal a change as I've managed to come up with. I'll revert to 37445d2 before merge.