### PR TITLE
Add a way to give definitions of terms as tooltips #31

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -188,6 +188,8 @@ function checkIfAllComponentsChecked() {
     return isAllChecked;
 }
 
+var totalWeeks = 15;
+var weeksLoaded = 0;
 function loadContent(week) {
     $.ajax({
         type: 'GET',
@@ -218,8 +220,13 @@ function loadContent(week) {
 
             if (typeof preview != 'undefined') {
                 expandWeekFully(week);
+                totalWeeks = 1;
             } else if (isCurrentWeek(week)) {
                 expandWeekFully(week);
+            }
+
+            if (++weeksLoaded == totalWeeks) {
+                $.getScript('../scripts/tooltip.js');
             }
         }
     });

--- a/scripts/tooltip.js
+++ b/scripts/tooltip.js
@@ -1,5 +1,5 @@
-// Maps a string to a definition (in the form of a HTML string)
-var definitions = {
+// Maps a string to a tooltip (in the form of a HTML string)
+var tooltips = {
 };
 
 // Maps a string to a list of aliases
@@ -7,18 +7,18 @@ var aliases = {
 }
 
 for (let term in aliases) {
-    let definition = definitions[term];
+    let tooltip = tooltips[term];
     let values = aliases[term];
     for (let i in values) {
-        alias = values[i];
-        definitions[alias] = definition;
+        let alias = values[i];
+        tooltips[alias] = tooltip;
     }
 }
 
 var count = 0;
 $('tooltip').each(function() {
     var term = $(this).text();
-    var title = definitions[term];
+    var title = tooltips[term];
     var id = String(count++);
     $(this).attr('id', id);
     $(this).tooltip({

--- a/scripts/tooltip.js
+++ b/scripts/tooltip.js
@@ -1,0 +1,9 @@
+var definitions = {
+};
+
+$('tooltip').each(function() {
+    var term = $(this).text();
+    var title = definitions[term];
+    $(this).attr('title', title);
+    $(this).tooltip();
+});

--- a/scripts/tooltip.js
+++ b/scripts/tooltip.js
@@ -1,9 +1,14 @@
 var definitions = {
 };
 
+var count = 0;
 $('tooltip').each(function() {
     var term = $(this).text();
     var title = definitions[term];
-    $(this).attr('title', title);
-    $(this).tooltip();
+    var id = String(count++);
+    $(this).attr('id', id);
+    $(this).tooltip({
+        items: '#' + id,
+        content: title
+    });
 });

--- a/scripts/tooltip.js
+++ b/scripts/tooltip.js
@@ -1,5 +1,19 @@
+// Maps a string to a definition (in the form of a HTML string)
 var definitions = {
 };
+
+// Maps a string to a list of aliases
+var aliases = {
+}
+
+for (let term in aliases) {
+    let definition = definitions[term];
+    let values = aliases[term];
+    for (let i in values) {
+        alias = values[i];
+        definitions[alias] = definition;
+    }
+}
 
 var count = 0;
 $('tooltip').each(function() {

--- a/scripts/tooltip.js
+++ b/scripts/tooltip.js
@@ -1,28 +1,30 @@
-// Maps a string to a tooltip (in the form of a HTML string)
-var tooltips = {
-};
+(function() {
+    // Maps a string to a tooltip (in the form of a HTML string)
+    var tooltips = {
+    };
 
-// Maps a string to a list of aliases
-var aliases = {
-}
-
-for (let term in aliases) {
-    let tooltip = tooltips[term];
-    let values = aliases[term];
-    for (let i in values) {
-        let alias = values[i];
-        tooltips[alias] = tooltip;
+    // Maps a string to a list of aliases
+    var aliases = {
     }
-}
 
-var count = 0;
-$('tooltip').each(function() {
-    var term = $(this).text();
-    var title = tooltips[term];
-    var id = String(count++);
-    $(this).attr('id', id);
-    $(this).tooltip({
-        items: '#' + id,
-        content: title
+    for (let term in aliases) {
+        let tooltip = tooltips[term];
+        let values = aliases[term];
+        for (let i in values) {
+            let alias = values[i];
+            tooltips[alias] = tooltip;
+        }
+    }
+
+    var count = 0;
+    $('tooltip').each(function() {
+        var term = $(this).text();
+        var title = tooltips[term];
+        var id = String(count++);
+        $(this).attr('id', id);
+        $(this).tooltip({
+            items: '#' + id,
+            content: title
+        });
     });
-});
+})();

--- a/styles/common.css
+++ b/styles/common.css
@@ -358,6 +358,10 @@ table.two-column-content td {
  * paragraph texts
  */
 
+ tooltip {
+     border-bottom: 1px dashed black;
+ }
+ 
  .deadline > div > ul > li {
     font-weight: bold;
  }


### PR DESCRIPTION
Fixes #31
[Preview: Week 0](http://rawgit.com/acjh/website/31-add-way-definition-tooltips/contents/week.html?preview=0)

This is still a proof-of-concept, suggestions welcome :)

> A hyperlink in a `tooltip` is **not** meant to be clicked, so don't get frustrated over trying to click it.
> It's just there to demo HTML content. But yes, it works.