### PR TITLE
Generate anchors for markdown headers in coding standards #222

### DIFF
--- a/contents/coding-standards-css.html
+++ b/contents/coding-standards-css.html
@@ -12,15 +12,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script>
         var markdownUrl = 'coding-standards-css.md';
-        
-        function processAndDisplayResult(html) {
-            // pre-process the result as necessary
-
-            // display the result in the page; this is the minimum requirement of the function
-            displayResult(html);
-
-            // post-process the result as necessary
-        }
     </script>
     <script src="../scripts/markdown.js"></script>
 </body>

--- a/contents/coding-standards-css.html
+++ b/contents/coding-standards-css.html
@@ -9,10 +9,8 @@
     <title>CSS Style Guide</title>
 </head>
 <body>
+    <div class="markdown-body" data-url="coding-standards-css.md"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script>
-        var markdownUrl = 'coding-standards-css.md';
-    </script>
     <script src="../scripts/markdown.js"></script>
 </body>
 </html>

--- a/contents/coding-standards-html.html
+++ b/contents/coding-standards-html.html
@@ -12,15 +12,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script>
         var markdownUrl = 'coding-standards-html.md';
-        
-        function processAndDisplayResult(html) {
-            // pre-process the result as necessary
-
-            // display the result in the page; this is the minimum requirement of the function
-            displayResult(html);
-
-            // post-process the result as necessary
-        }
     </script>
     <script src="../scripts/markdown.js"></script>
 </body>

--- a/contents/coding-standards-html.html
+++ b/contents/coding-standards-html.html
@@ -9,10 +9,8 @@
     <title>HTML Style Guide</title>
 </head>
 <body>
+    <div class="markdown-body" data-url="coding-standards-html.md"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script>
-        var markdownUrl = 'coding-standards-html.md';
-    </script>
     <script src="../scripts/markdown.js"></script>
 </body>
 </html>

--- a/contents/coding-standards-html.md
+++ b/contents/coding-standards-html.md
@@ -182,7 +182,7 @@
   header-content-week3
   ```
 
-## Indentation<a name="indentation"></a>
+## Indentation
 - Indentation should be 2 spaces for html files.
 - Spaces should be used instead of `tab`.
 

--- a/contents/coding-standards-java.html
+++ b/contents/coding-standards-java.html
@@ -13,15 +13,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script>
         var markdownUrl = 'coding-standards-java.md';
-        
-        function processAndDisplayResult(html) {
-            // pre-process the result as necessary
-
-            // display the result in the page; this is the minimum requirement of the function
-            displayResult(html);
-
-            // post-process the result as necessary
-        }
     </script>
     <script src="../scripts/markdown.js"></script>
 </body>

--- a/contents/coding-standards-java.html
+++ b/contents/coding-standards-java.html
@@ -10,10 +10,8 @@
     <title>Java Coding Standard</title>
 </head>
 <body>
+    <div class="markdown-body" data-url="coding-standards-java.md"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script>
-        var markdownUrl = 'coding-standards-java.md';
-    </script>
     <script src="../scripts/markdown.js"></script>
 </body>
 </html>

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -10,7 +10,7 @@ $.ajax({
             url: "https://api.github.com/markdown",
             data: JSON.stringify({
                 "text": data,
-                "mode": "gfm"
+                "mode": "markdown"
             }),
             error: function(jqXHR, textStatus, error) {
                 redirectToGithub();

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -1,3 +1,5 @@
+var markdownUrl = $('.markdown-body').attr('data-url');
+
 $.ajax({
     type: 'GET',
     url: markdownUrl,
@@ -27,7 +29,7 @@ function redirectToGithub() {
 }
 
 function displayResult(html) {
-    $(document.body).html($('<div class="markdown-body">' + html + '</div>'));
+    $('.markdown-body').html(html);
 }
 
 function processAndDisplayResult(html) {

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -32,9 +32,10 @@ function displayResult(html) {
 
 function processAndDisplayResult(html) {
     // Pre-process the result as necessary
+    html = html.replace(/user-content-/g, '');
     html = html.replace(/<th align="center">Good<\/th>/g, '<th align="center" class="example-good">Good</th>');
     html = html.replace(/<th align="center">Bad<\/th>/g, '<th align="center" class="example-bad">Bad</th>');
-    html = html.replace('id="user-content-borderless"', 'class="borderless"');
+    html = html.replace('id="borderless"', 'class="borderless"');
 
     // Display the result in the page; this is the minimum requirement of the function
     displayResult(html);

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -16,9 +16,6 @@ $.ajax({
                 redirectToGithub();
             },
             success: function(data) {
-                data = data.replace(/<th align="center">Good<\/th>/g, '<th align="center" class="example-good">Good</th>');
-                data = data.replace(/<th align="center">Bad<\/th>/g, '<th align="center" class="example-bad">Bad</th>');
-                data = data.replace('id="user-content-borderless"', 'class="borderless"');
                 processAndDisplayResult(data);
             }
         });
@@ -35,6 +32,9 @@ function displayResult(html) {
 
 function processAndDisplayResult(html) {
     // Pre-process the result as necessary
+    html = html.replace(/<th align="center">Good<\/th>/g, '<th align="center" class="example-good">Good</th>');
+    html = html.replace(/<th align="center">Bad<\/th>/g, '<th align="center" class="example-bad">Bad</th>');
+    html = html.replace('id="user-content-borderless"', 'class="borderless"');
 
     // Display the result in the page; this is the minimum requirement of the function
     displayResult(html);

--- a/scripts/markdown.js
+++ b/scripts/markdown.js
@@ -32,3 +32,12 @@ function redirectToGithub() {
 function displayResult(html) {
     $(document.body).html($('<div class="markdown-body">' + html + '</div>'));
 }
+
+function processAndDisplayResult(html) {
+    // Pre-process the result as necessary
+
+    // Display the result in the page; this is the minimum requirement of the function
+    displayResult(html);
+
+    // Post-process the result as necessary
+}


### PR DESCRIPTION
Fixes #222
Preview:
- [.../contents/coding-standards-css.html](http://rawgit.com/acjh/website/222-generate-anchors-for-markdown/contents/coding-standards-css.html)
- [.../contents/coding-standards-html.html](http://rawgit.com/acjh/website/222-generate-anchors-for-markdown/contents/coding-standards-html.html)
- [.../contents/coding-standards-java.html](http://rawgit.com/acjh/website/222-generate-anchors-for-markdown/contents/coding-standards-java.html)