### PR TITLE
Code samples in embedded content are blacked out #228

### DIFF
--- a/contents/handbook.html
+++ b/contents/handbook.html
@@ -215,11 +215,7 @@
 
 </script>
 <p>-------------------------------------End of document----------------------------------------</p>
+<script type="text/javascript" src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?skin=sunburst"></script>
 <script type="text/javascript" src="../scripts/handbook.js"></script>
-<script>
-    $(document).ready(function() {
-        $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?skin=sunburst");
-    });
-</script>
 </body>
 </html>

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -38,8 +38,25 @@ function pullContent(fileName, elementSelector, title, sectionName) {
                ' $(\'' + elementSelector + '\').removeClass(\'embedded\');" ' +
                'class="btn-dismiss-embedded">X</button></div><br> '+linkNotice+' </div>');
             $(elementSelector + ' > div > .btn-dismiss').button();
+
+            if ($('.prettyprint:not(.prettyprinted)').length > 0) {
+                prettyPrintCodeSamples();
+            }
         }
-    }); 
+    });
+}
+
+/**
+ * Pretty-prints code samples.
+ * If PR is undefined, get run_prettify.js with 'sunburst' skin,
+ * else, call prettyPrint() that is defined in the above script.
+ */
+function prettyPrintCodeSamples() {
+    if (typeof PR == "undefined") {
+        $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?skin=sunburst");
+    } else {
+        PR.prettyPrint();
+    }
 }
 
 function addCollapseAndExpandButtonsForComponents(accordionHeaderSelector, divId) {

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -96,6 +96,9 @@ function loadSectionUsingAjax(section, callback) {
                     }
                 });
             }
+            if ($('.prettyprint:not(.prettyprinted)').length > 0) {
+                PR.prettyPrint();
+            }
         }
     });
 }
@@ -127,10 +130,11 @@ function isTableOfContentVisible() {
 }
 
 /**
- * Loads sections based on whether preview has been requested.
- * If not preview, hold $(document).ready until ajax callback.
+ * Loads sections, based on whether a preview was requested.
+ * If preview, the remaining anchors trigger load-on-demand,
+ * else, the remaining anchors jump to section heading only.
  */
-function loadSectionsBeforeDocumentReady() {
+function loadSections() {
     var preview = window.location.href.match(/\?preview=([^&#]*)/);
 
     if (preview) {
@@ -143,9 +147,7 @@ function loadSectionsBeforeDocumentReady() {
         $('a[href="#' + section + '"]').click();
         $('#overlay').remove();
     } else {
-        $.holdReady(true);
         var callback = function() {
-            $.holdReady(false);
             $('#overlay').remove();
         }
         loadAllSectionsUsingAjax(callback);
@@ -153,9 +155,9 @@ function loadSectionsBeforeDocumentReady() {
     }
 }
 
-loadSectionsBeforeDocumentReady();
-
 $(document).ready(function() {
+    loadSections();
+
     var buttonAnimationDuration = 200;
     var speed = 1;
 


### PR DESCRIPTION
Fixes #228 
[Preview](http://rawgit.com/acjh/website/228-code-samples-blacked-out/contents/week.html?preview=11)