### PR TITLE
Fix broken links and update outdated content in search page

### DIFF
--- a/contents/search.html
+++ b/contents/search.html
@@ -162,9 +162,8 @@
               <category text="Implementation">
                 <keyword text="Graded based on qualities of your own code" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
-              <category text="Testing">
-                <keyword text="How much effort you have invested in the testing process?" href="handbook.html#handbook-project-assessment"></keyword>
-                <keyword text="How well you have tested the product" href="handbook.html#handbook-project-assessment"></keyword>
+              <category text="QA">
+                <keyword text="How good is your Quality Assurance?" href="handbook.html#handbook-project-assessment"></keyword>
                 <keyword text="Expectations" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Documentation">

--- a/contents/search.html
+++ b/contents/search.html
@@ -29,13 +29,13 @@
           <keyword text="Attendance" href="handbook.html#handbook-lectures"></keyword>
           <keyword text="Webcast" href="handbook.html#handbook-lectures"></keyword>
           <category text="Handouts">
-            <keyword text="Where to find handouts" href="handbook.html#handbook-lectures"></keyword>
-            <keyword text="When to read handouts" href="handbook.html#handbook-lectures"></keyword>
+            <keyword text="Where to find handouts?" href="handbook.html#handbook-lectures"></keyword>
+            <keyword text="When to read handouts?" href="handbook.html#handbook-lectures"></keyword>
           </category>
           <keyword text="Post-lecture quizzes" href="handbook.html#handbook-lectures"></keyword>
           <category text="Slides">
             <keyword text="When are slides released?" href="handbook.html#handbook-lectures"></keyword>
-            <keyword text="Where to find slides" href="handbook.html#handbook-lectures"></keyword>
+            <keyword text="Where to find slides?" href="handbook.html#handbook-lectures"></keyword>
           </category>
         </main-category>
         <main-category text="Tutorials" type="primary" label="Handbook" href="handbook.html#handbook-tutorials">
@@ -46,7 +46,7 @@
             <keyword text="No leading from the front" href="handbook.html#handbook-tutorials"></keyword>
           </category>
           <keyword text="Timing/venue" href="handbook.html#handbook-tutorials"></keyword>
-          <category text="How participation marks are awarded?">
+          <category text="How are participation marks awarded?">
             <keyword text="Punctuality" href="handbook.html#handbook-tutorials"></keyword>
             <keyword text="Attention" href="handbook.html#handbook-tutorials"></keyword>
             <keyword text="Effort" href="handbook.html#handbook-tutorials"></keyword>
@@ -65,14 +65,14 @@
           <keyword text="How do I get help?" href="handbook.html#handbook-programmingLanguages"></keyword>
         </main-category>
         <main-category text="Project" type="primary" label="Handbook" href="handbook.html#handbook-project">
-          <category text="The product">
+          <category text="The Product">
             <keyword text="Problem outline" href="handbook.html#handbook-project-product"></keyword>
             <keyword text="Solution outline" href="handbook.html#handbook-project-product"></keyword>
             <keyword text="Target audience" href="handbook.html#handbook-project-product"></keyword>
           </category>
           <category text="Product Scope">
             <keyword text="Must-have features" href="handbook.html#handbook-project-scope"></keyword>
-            <category text="Nice to have features">
+            <category text="Nice-to-have features">
               <keyword text="Difficulty-low" href="handbook.html#handbook-project-scope"></keyword>
               <keyword text="Difficulty-medium" href="handbook.html#handbook-project-scope"></keyword>
               <keyword text="Difficulty-high" href="handbook.html#handbook-project-scope"></keyword>
@@ -88,7 +88,7 @@
                 <keyword text="User Guide" href="handbook.html#handbook-project-v00"></keyword>
                 <keyword text="User stories" href="handbook.html#handbook-project-v00"></keyword>
                 <keyword text="Non-functional requirements" href="handbook.html#handbook-project-v00"></keyword>
-                <keyword text="Prodcut Survey" href="handbook.html#handbook-project-v00"></keyword>
+                <keyword text="Product Survey" href="handbook.html#handbook-project-v00"></keyword>
               </category>
               <keyword text="Submission" href="handbook.html#handbook-project-v00"></keyword>
               <keyword text="Grading" href="handbook.html#handbook-project-v00"></keyword>
@@ -151,7 +151,7 @@
             </category>
             <category text="Project Assessment">
               <category text="Product features">
-                <keyword text="Must have features" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Must-have features" href="handbook.html#handbook-project-assessment"></keyword>
                 <keyword text="Extra features" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Design">
@@ -163,7 +163,7 @@
                 <keyword text="Graded based on qualities of your own code" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Testing">
-                <keyword text="How much effort you have invested in the testing process" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="How much effort you have invested in the testing process?" href="handbook.html#handbook-project-assessment"></keyword>
                 <keyword text="How well you have tested the product" href="handbook.html#handbook-project-assessment"></keyword>
                 <keyword text="Expectations" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
@@ -276,8 +276,8 @@
           <keyword text="[Optional] A safer workflow using forks and pull requests" href="handbook.html#workflow"></keyword>
         </main-category>
         <main-category text="Appendix F: What to do if there are teamwork issues" type="primary" label="Handbook" href="handbook.html#handbook-appendixF-teamworkIssues">
-          <keyword text="What to do if my team is facing difficulties due to differences in skill/motivation/availability among team members" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
-          <keyword text="What to do if I have very unreliable or totally disengaged team members " href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
+          <keyword text="What to do if my team is facing difficulties due to differences in skill/motivation/availability among team members?" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
+          <keyword text="What to do if I have very unreliable or totally disengaged team members?" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
           <category text="Suggestions">
             <keyword text="Redistribute the work" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
             <keyword text="Enforce stricter integration workflow" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>

--- a/contents/search.html
+++ b/contents/search.html
@@ -26,7 +26,7 @@
         </main-category>
         <main-category text="Lectures" type="primary" label="Handbook" href="handbook.html#handbook-lectures">
           <keyword text="Timing/venue" href="handbook.html#handbook-lectures"></keyword>
-          <keyword text="Attendance requirements" href="handbook.html#handbook-lectures"></keyword>
+          <keyword text="Attendance" href="handbook.html#handbook-lectures"></keyword>
           <keyword text="Webcast" href="handbook.html#handbook-lectures"></keyword>
           <category text="Handouts">
             <keyword text="Where to find handouts" href="handbook.html#handbook-lectures"></keyword>
@@ -46,7 +46,11 @@
             <keyword text="No leading from the front" href="handbook.html#handbook-tutorials"></keyword>
           </category>
           <keyword text="Timing/venue" href="handbook.html#handbook-tutorials"></keyword>
-          <keyword text="How participation points are awarded for tutorials" href="handbook.html#handbook-tutorials"></keyword>
+          <category text="How participation marks are awarded?">
+            <keyword text="Punctuality" href="handbook.html#handbook-tutorials"></keyword>
+            <keyword text="Attention" href="handbook.html#handbook-tutorials"></keyword>
+            <keyword text="Effort" href="handbook.html#handbook-tutorials"></keyword>
+          </category>
           <category text="Expectations">
             <keyword text="Please bring your laptop to tutorials" href="handbook.html#handbook-tutorials"></keyword>
             <keyword text="Pay attention to discussions" href="handbook.html#handbook-tutorials"></keyword>
@@ -66,19 +70,19 @@
             <keyword text="Solution outline" href="handbook.html#handbook-project-product"></keyword>
             <keyword text="Target audience" href="handbook.html#handbook-project-product"></keyword>
           </category>
-          <category text="Product scope">
+          <category text="Product Scope">
             <keyword text="Must-have features" href="handbook.html#handbook-project-scope"></keyword>
-            <category text="Extra features">
+            <category text="Nice to have features">
               <keyword text="Difficulty-low" href="handbook.html#handbook-project-scope"></keyword>
               <keyword text="Difficulty-medium" href="handbook.html#handbook-project-scope"></keyword>
               <keyword text="Difficulty-high" href="handbook.html#handbook-project-scope"></keyword>
             </category>
             <keyword text="Target audience" href="handbook.html#handbook-project-scope"></keyword>
           </category>
-          <keyword text="Project constraints" href="handbook.html#handbook-project-constraints"></keyword>
-          <category text="Deliverables">
+          <keyword text="Project Constraints" href="handbook.html#handbook-project-constraints"></keyword>
+          <category text="Project Deliverables">
             <category text="V0.0 : The Concept">
-              <keyword text="Techniques to be applied" href="handbook.html#handbook-project-v00"></keyword>
+              <keyword text="Objective" href="handbook.html#handbook-project-v00"></keyword>
               <category text="Sections to include">
                 <keyword text="About Us Page" href="handbook.html#handbook-project-v00"></keyword>
                 <keyword text="User Guide" href="handbook.html#handbook-project-v00"></keyword>
@@ -86,124 +90,113 @@
                 <keyword text="Non-functional requirements" href="handbook.html#handbook-project-v00"></keyword>
                 <keyword text="Prodcut Survey" href="handbook.html#handbook-project-v00"></keyword>
               </category>
+              <keyword text="Submission" href="handbook.html#handbook-project-v00"></keyword>
+              <keyword text="Grading" href="handbook.html#handbook-project-v00"></keyword>
             </category>
-            <category text="V0.1: The Walking Skeleton">
+            <category text="V0.1 : The Walking Skeleton">
+              <keyword text="Product" href="handbook.html#handbook-project-v01-product"></keyword>
+              <keyword text="Demo" href="handbook.html#handbook-project-v01-demo"></keyword>
+              <keyword text="Documentation" href="handbook.html#handbook-project-v01-documentation"></keyword>
             </category>
             </category>
-            <category text="V0.2 Demo and Feedback Session">
-              <keyword text="Objective" href="handbook.html#handbook-v02Demo"></keyword>
-              <keyword text="Schedule" href="handbook.html#handbook-v02Demo"></keyword>
+            <category text="V0.2 : The MVP">
+              <keyword text="Product" href="handbook.html#handbook-project-v02-product"></keyword>
+              <keyword text="Demo" href="handbook.html#handbook-project-v02-demo"></keyword>
+              <keyword text="Documentation" href="handbook.html#handbook-project-v02-documentation"></keyword>
             </category>
-            <category text="V0.2-V0.4 of the Project Manual">
-              <keyword text="What to do?" href="handbook.html#handbook-v02Manual"></keyword>
+            <category text="V0.3">
+              <keyword text="Product" related="dog fooding" href="handbook.html#handbook-project-v03-product"></keyword>
+              <keyword text="Documentation" href="handbook.html#handbook-project-v03-documentation"></keyword>
+              <keyword text="Demo" href="handbook.html#handbook-project-v03-demo"></keyword>
             </category>
-            <category text="V0.2-V0.4 of the Product">
-              <keyword text="What to do?" related="production quality" href="handbook.html#handbook-v02Product"></keyword>
-              <keyword text="Submission" related="git tag" href="handbook.html#handbook-v02Product"></keyword>
+            <category text="V0.4">
+              <category text="Product">
+                <keyword text="Dogfood your product" related="dog food fooding" href="handbook.html#handbook-project-v04-product"></keyword>
+                <keyword text="Mark your code" related="collate md markdown tool evaluation" href="handbook.html#handbook-project-v04-product"></keyword>
+                <keyword text="Code quality grading" href="handbook.html#handbook-project-v04-product"></keyword>
+              </category>
+              <keyword text="Documentation" href="handbook.html#handbook-project-v04-documentation"></keyword>
+              <keyword text="Demo" href="handbook.html#handbook-project-v04-demo"></keyword>
             </category>
-            <category text="V0.2-V0.4 Grading">
-              <keyword text="Grading" related="production quality" href="handbook.html#handbook-v02Grading"></keyword>
-              <keyword text="Deadline" related="git tag" href="handbook.html#handbook-v02Grading"></keyword>
+            <category text="V0.5rc : The Release Candidate">
+              <category text="Product" related="freeze features">
+                <keyword text="Freeze features" href="handbook.html#handbook-project-v05rc-product"></keyword>
+                <keyword text="Have sufficient code coverage" href="handbook.html#handbook-project-v05rc-product"></keyword>
+              <keyword text="Documentation" href="handbook.html#handbook-project-v05rc-documentation"></keyword>
+              <keyword text="Demo" href="handbook.html#handbook-project-v05rc-demo"></keyword>
             </category>
-            <category text="V0.4[release candidate] Additional Requirements">
-              <keyword text="Freeze features" href="handbook.html#handbook-v04Product"></keyword>
-              <keyword text="Use binaries" related="jar exe" href="handbook.html#handbook-v04Product"></keyword>
-              <keyword text="Ensure runnability" related="windows 32bit environment" href="handbook.html#handbook-v04Product"></keyword>
-              <keyword text="Mark your code" related="collate md markdown tool evaluation" href="handbook.html#handbook-v04Product"></keyword>
-            </category>
-            <category text="V0.5 [production release] Additional Requirements">
-              <keyword text="Production quality" href="handbook.html#handbook-v05Requirements"></keyword>
-              <keyword text="Updated *.md files" href="handbook.html#handbook-v05Requirements"></keyword>
-              <keyword text="Page limit" href="handbook.html#handbook-v05Requirements"></keyword>
-              <keyword text="Video demo [optional]" href="handbook.html#handbook-v05Requirements"></keyword>
-            </category>
-            <category text="V0.5 Submission">
-              <keyword text="Source code" href="handbook.html#handbook-v05Submission"></keyword>
-              <keyword text="Executable" href="handbook.html#handbook-v05Submission"></keyword>
-              <keyword text="Project manual" related="hard copy binding color stapling double-side" href="handbook.html#handbook-v05Submission"></keyword>
-              <keyword text="Deadline" href="handbook.html#handbook-v05Submission"></keyword>
-            </category>
-            <category text="V0.5 Demo and Q&A Session">
-              <category text="Demo">
-                <category text="FAQ">
-                  <keyword text="Dress code" href="handbook.html#handbook-v05Demo"></keyword>
-                  <keyword text="Punctuality" href="handbook.html#handbook-v05Demo"></keyword>
-                  <keyword text="Use of slides" href="handbook.html#handbook-v05Demo"></keyword>
-                  <keyword text="Use of videos" href="handbook.html#handbook-v05Demo"></keyword>
-                  <keyword text="Should every team member present?" href="handbook.html#handbook-v05Demo"></keyword>
-                </category>
-                <keyword text="Things to prepare" href="handbook.html#handbook-v05Demo"></keyword>
+            <category text="V0.5 : The Production Release">
+              <keyword text="Product" related="production quality" href="handbook.html#handbook-project-v05-product"></keyword>
+              <keyword text="Documentation" href="handbook.html#handbook-project-v05-documentation"></keyword>
+              <category text="Demo" href="handbook.html#handbook-project-v05-demo">
+                <keyword text="Dress code" href="handbook.html#handbook-project-v05-demo"></keyword>
+                <keyword text="Punctuality" href="handbook.html#handbook-project-v05-demo"></keyword>
+                <keyword text="Use of slides" href="handbook.html#handbook-project-v05-demo"></keyword>
+                <keyword text="Use of videos" href="handbook.html#handbook-project-v05-demo"></keyword>
+                <keyword text="Should every team member present?" href="handbook.html#handbook-project-v05-demo"></keyword>
               </category>
             </category>
             <category text="Project retrospective">
-              <keyword text="What should be written?" href="handbook.html#handbook-projectRetrospective"></keyword>
-              <keyword text="Suggested length" href="handbook.html#handbook-projectRetrospective"></keyword>
-              <keyword text="Submission" related="TEAMMATES" href="handbook.html#handbook-projectRetrospective"></keyword>
-              <keyword text="Deadline" href="handbook.html#handbook-projectRetrospective"></keyword>
+              <keyword text="What should be written?" href="handbook.html#handbook-project-retrospective"></keyword>
+              <keyword text="Suggested length" href="handbook.html#handbook-project-retrospective"></keyword>
+              <keyword text="Submission" related="TEAMMATES" href="handbook.html#handbook-project-retrospective"></keyword>
+              <keyword text="Deadline" href="handbook.html#handbook-project-retrospective"></keyword>
             </category>
             <category text="Individual report">
-              <keyword text="Purpose" href="handbook.html#handbook-individualReport"></keyword>
-              <keyword text="What should be written?" href="handbook.html#handbook-individualReport"></keyword>
-              <keyword text="Suggested length" href="handbook.html#handbook-individualReport"></keyword>
-              <keyword text="Submission" related="TEAMMATES" href="handbook.html#handbook-individualReport"></keyword>
-              <keyword text="Deadline" href="handbook.html#handbook-individualReport"></keyword>
+              <keyword text="Purpose" href="handbook.html#handbook-project-individualReport"></keyword>
+              <keyword text="What should be written?" href="handbook.html#handbook-project-individualReport"></keyword>
+              <keyword text="Suggested length" href="handbook.html#handbook-project-individualReport"></keyword>
+              <keyword text="Submission" related="TEAMMATES" href="handbook.html#handbook-project-individualReport"></keyword>
+              <keyword text="Deadline" href="handbook.html#handbook-project-individualReport"></keyword>
             </category>
-            <category text="V0.5 Evaluation">
+            <category text="Project Assessment">
               <category text="Product features">
-                <keyword text="Must have features" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Extra features" href="handbook.html#handbook-v05Evaluation"></keyword>
+                <keyword text="Must have features" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Extra features" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Design">
-                <keyword text="Conformance with the multi-level top-down approach" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Conformance with the OO paradigm" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Application of patterns and principles" href="handbook.html#handbook-v05Evaluation"></keyword>
+                <keyword text="Conformance with the multi-level top-down approach" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Conformance with the OO paradigm" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Application of patterns and principles" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Implementation">
-                <keyword text="Graded based on qualities of your own code" href="handbook.html#handbook-v05Evaluation"></keyword>
+                <keyword text="Graded based on qualities of your own code" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Testing">
-                <keyword text="How much effort you have invested in the testing process" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="How well you have tested the product" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Expectations" href="handbook.html#handbook-v05Evaluation"></keyword>
+                <keyword text="How much effort you have invested in the testing process" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="How well you have tested the product" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Expectations" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Documentation">
-                <keyword text="User guide" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Developer guide" href="handbook.html#handbook-v05Evaluation"></keyword>
+                <keyword text="User guide" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Developer guide" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
               <category text="Project management">
-                <keyword text="Good version control, based on the repo" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Good task definition, assignment and tracking, based on the issue tracker" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Good use of buffers (opposite: everything at the last minute)" href="handbook.html#handbook-v05Evaluation"></keyword>
-                <keyword text="Iterative (opposite: fake iterative, doing most of the work in one iteration)" href="handbook.html#handbook-v05Evaluation"></keyword>
+                <keyword text="Good version control, based on the repo" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Good task definition, assignment and tracking, based on the issue tracker" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Good use of buffers (opposite: everything at the last minute)" href="handbook.html#handbook-project-assessment"></keyword>
+                <keyword text="Iterative (opposite: fake iterative, doing most of the work in one iteration)" href="handbook.html#handbook-project-assessment"></keyword>
               </category>
-              <keyword text="Penalty for late submission" href="handbook.html#handbook-v05Evaluation"></keyword>
+              <keyword text="Penalty for late submission" href="handbook.html#handbook-project-assessment"></keyword>
             </category>
           </category>
+          <category text="Project Supervision">
+            <keyword text="How can I get help from project supervisor?" href="handbook.html#handbook-project-supervision"></keyword>
+          </category>
           <category text="Forming teams">
-            <keyword text="Team size" href="handbook.html#handbook-formingTeams"></keyword>
-            <keyword text="Roles and responsibilities" href="handbook.html#handbook-formingTeams"></keyword>
-            <keyword text="Team composition" href="handbook.html#handbook-formingTeams"></keyword>
-          </category>
-          <category text="Supervision">
-            <keyword text="How can I get help from project supervisor?" href="handbook.html#handbook-supervision"></keyword>
-          </category>
-          <category text="Project grading">
-            <keyword text="Will the project grades be curved?" href="handbook.html#handbook-projectGrading"></keyword>
-            <keyword text="Will I receive team grades or individual project grades?" related="contribution" href="handbook.html#handbook-projectGrading"></keyword>
-            <keyword text="Can exam performance affect project marks?" related="contribution" href="handbook.html#handbook-projectGrading"></keyword>
-            <keyword text="Is it ok if I did less-than-equal-share of contributions ?" related="contribution" href="handbook.html#handbook-projectGrading"></keyword>
-            <keyword text="Will C++ and Java projects graded together?" related="contribution" href="handbook.html#handbook-projectGrading"></keyword>
-            <keyword text="Will CS2103 and CS2103T projects graded together?" related="contribution" related="contribution" href="handbook.html#handbook-projectGrading"></keyword>
+            <keyword text="Team size" href="handbook.html#handbook-teams"></keyword>
+            <keyword text="Roles and responsibilities" href="handbook.html#handbook-teams"></keyword>
+            <keyword text="Team composition" href="handbook.html#handbook-teams"></keyword>
           </category>
           <category text="Peer Evaluations">
             <keyword text="How to do peer evaluations?" href="handbook.html#handbook-peerEvaluations"></keyword>
             <keyword text="Can peer evaluation affect my grade?" href="handbook.html#handbook-peerEvaluations"></keyword>
           </category>
           <category text="Project Tools">
-            <keyword text="Communication" related="Google Groups Email" href="handbook.html#handbook-projectTools"></keyword>
-            <keyword text="Collaboration platform" related="Github Repository Issue Tracker" href="handbook.html#handbook-projectTools"></keyword>
-            <keyword text="IDE" related="integrated development environment Eclipse Visual Studio 2012" href="handbook.html#handbook-projectTools"></keyword>
-            <keyword text="Revision control" related="SourceTree Git Mercurial" href="handbook.html#handbook-projectTools"></keyword>
+            <keyword text="Communication" related="Google Groups Email" href="handbook.html#handbook-tools"></keyword>
+            <keyword text="Collaboration platform" related="Github Repository Issue Tracker" href="handbook.html#handbook-tools"></keyword>
+            <keyword text="IDE" related="integrated development environment Eclipse Visual Studio 2012" href="handbook.html#handbook-tools"></keyword>
+            <keyword text="Revision control" related="SourceTree Git Mercurial" href="handbook.html#handbook-tools"></keyword>
           </category>
         </main-category>
       </div>
@@ -218,29 +211,25 @@
           <keyword text="Final exam" href="handbook.html#handbook-gradeBreakdown"></keyword>
           <keyword text="Participation" href="handbook.html#handbook-gradeBreakdown"></keyword>
         </main-category>
-        <main-category text="Participation Points" type="primary" label="Handbook" href="handbook.html#handbook-participationPoints">
-          <keyword text="How to earn full participation marks?" href="handbook.html#handbook-participationPoints"></keyword>
-          <category text="How to get points?">
-            <keyword text="Tutorial activities" href="handbook.html#handbook-participationPoints"></keyword>
-            <keyword text="Coding exercises" href="handbook.html#handbook-participationPoints"></keyword>
-            <keyword text="Peer evaluations" href="handbook.html#handbook-participationPoints"></keyword>
-            <keyword text="Intermediate project submissions" href="handbook.html#handbook-participationPoints"></keyword>
-            <keyword text="Other ad hoc opportunities offered during the module" related="submit a survey in-lecture activities" href="handbook.html#handbook-participationPoints"></keyword>
-            <keyword text="eXperience Points (XP)" href="handbook.html#handbook-participationPoints"></keyword>
+        <main-category text="Participation Marks" type="primary" label="Handbook" href="handbook.html#handbook-participation">
+          <keyword text="How to earn full participation marks?" href="handbook.html#handbook-participation"></keyword>
+          <category text="Criteria">
+            <keyword text="Consistent Effort" href="handbook.html#handbook-participation"></keyword>
+            <keyword text="Timeliness" href="handbook.html#handbook-participation"></keyword>
+            <keyword text="Teamwork" href="handbook.html#handbook-participation"></keyword>
+            <keyword text="Reliability" href="handbook.html#handbook-participation"></keyword>
+            <keyword text="Meticulousness" href="handbook.html#handbook-participation"></keyword>
           </category>
-          <keyword text="Earning points" href="handbook.html#handbook-participationPoints"></keyword>
-          <keyword text="Purpose" href="handbook.html#handbook-participationPoints"></keyword>
-          <keyword text="Checking the score" href="handbook.html#handbook-participationPoints"></keyword>
-          <keyword text="What if there is a discrepancy?" href="handbook.html#handbook-participationPoints"></keyword>
+          <keyword text="Purpose" href="handbook.html#handbook-participation"></keyword>
         </main-category>
-        <main-category text="Appendix A: Module Principles" type="primary" label="Handbook" href="handbook.html#handbook-appendixA">
-          <keyword text="Purpose of this module" href="handbook.html#handbook-appendixA"></keyword>
-          <keyword text="Necessary aspects to be more professional" href="handbook.html#handbook-appendixA"></keyword>
-          <keyword text="Learn together, NOT compete against each other" href="handbook.html#handbook-appendixA"></keyword>
-          <keyword text="Continuously engage, NOT last minute heroics" href="handbook.html#handbook-appendixA"></keyword>
-          <keyword text="Where you reach at the end matters, NOT what you knew at the beginning" href="handbook.html#handbook-appendixA"></keyword>
+        <main-category text="Appendix A: Module Principles" type="primary" label="Handbook" href="handbook.html#handbook-appendixA-principles">
+          <keyword text="Purpose of this module" href="handbook.html#handbook-appendixA-principles"></keyword>
+          <keyword text="Necessary aspects to be more professional" href="handbook.html#handbook-appendixA-principles"></keyword>
+          <keyword text="Learn together, NOT compete against each other" href="handbook.html#handbook-appendixA-principles"></keyword>
+          <keyword text="Continuously engage, NOT last minute heroics" href="handbook.html#handbook-appendixA-principles"></keyword>
+          <keyword text="Where you reach at the end matters, NOT what you knew at the beginning" href="handbook.html#handbook-appendixA-principles"></keyword>
         </main-category>
-        <main-category text="Appendix B: Module Policies" type="primary" label="Handbook" href="handbook.html#handbook-appendixB">
+        <main-category text="Appendix B: Module Policies" type="primary" label="Handbook" href="handbook.html#handbook-appendixB-policies">
           <keyword text="Policy on following instructions" href="handbook.html#policy-followingInstructions"></keyword>
           <keyword text="Policy on grading smaller/larger teams" href="handbook.html#policy-teamSize"></keyword>
           <keyword text="Policy on project work distribution" href="handbook.html#policy-workDistribution"></keyword>
@@ -253,7 +242,7 @@
           <keyword text="Policy on help from outsiders" href="handbook.html#policy-outsiderHelp"></keyword>
           <keyword text="Policy on suggested length for submissions" href="handbook.html#policy-submissionLength"></keyword>
         </main-category>
-        <main-category text="Appendix C: Frequently Asked Questions" type="primary" label="Handbook" href="handbook.html#handbook-appendixC">
+        <main-category text="Appendix C: Frequently Asked Questions" type="primary" label="Handbook" href="handbook.html#handbook-appendixC-faq">
           <keyword text="Why the workload is so high?" href="handbook.html#handbook-faq-highWorkload"></keyword>
           <keyword text="Why so much bean counting?" href="handbook.html#handbook-faq-beanCounting"></keyword>
           <keyword text="Why you force me to visit a separate website instead of using IVLE?" href="handbook.html#handbook-faq-separateWebsite"></keyword>
@@ -268,29 +257,30 @@
           <keyword text="Why not enough marks for intermediate submissions?" href="handbook.html#handbook-faq-intermediateMarks"></keyword>
           <keyword text="Why submission requirements differ between CS2103T and CS2101?" href="handbook.html#handbook-faq-cs2101Differences"></keyword>
         </main-category>
-        <main-category text="Appendix D: How to get tech help in CS2103/T" type="primary" label="Handbook" href="handbook.html#handbook-appendixD">
-          <keyword text="Can I get tech help in this module?" href="handbook.html#handbook-appendixD"></keyword>
-          <keyword text="What not to do?" href="handbook.html#handbook-appendixD"></keyword>
+        <main-category text="Appendix D: How to get tech help in CS2103/T" type="primary" label="Handbook" href="handbook.html#handbook-appendixD-help">
+          <keyword text="Can I get tech help in this module?" href="handbook.html#handbook-appendixD-help"></keyword>
+          <keyword text="What not to do?" href="handbook.html#handbook-appendixD-help"></keyword>
           <category text="What should I do when I face a tech problem?">
-            <keyword text="Check what is given" href="handbook.html#handbook-appendixD"></keyword>
-            <keyword text="Search" href="handbook.html#handbook-appendixD"></keyword>
-            <keyword text="Ask peers" href="handbook.html#handbook-appendixD"></keyword>
-            <keyword text="Request tutors help" href="handbook.html#handbook-appendixD"></keyword>
+            <keyword text="Check what is given" href="handbook.html#handbook-appendixD-help"></keyword>
+            <keyword text="Search" href="handbook.html#handbook-appendixD-help"></keyword>
+            <keyword text="Ask peers" href="handbook.html#handbook-appendixD-help"></keyword>
+            <keyword text="Request tutors help" href="handbook.html#handbook-appendixD-help"></keyword>
           </category>
         </main-category>
-        <main-category text="Appendix E: Using GitHub Project Hosting" type="primary" label="Handbook" href="handbook.html#handbook-appendixE">
-          <keyword text="Organization setup" href="handbook.html#handbook-appendixE"></keyword>
-          <keyword text="Repo setup" href="handbook.html#handbook-appendixE"></keyword>
-          <keyword text="Issue tracker setup" href="handbook.html#handbook-appendixE"></keyword>
-          <keyword text="Guidelines for Task Tracking using the Issue Tracker" href="handbook.html#handbook-appendixE"></keyword>
-          <keyword text="[Optional] A safer workflow using forks and pull requests" href="handbook.html#handbook-appendixE"></keyword>
+        <main-category text="Appendix E: Using GitHub Project Hosting" type="primary" label="Handbook" href="handbook.html#handbook-appendixE-github">
+          <keyword text="Submitting Pull Requests for tutorials" href="handbook.html#tutorial-pr-instructions"></keyword>
+          <keyword text="Organization setup" href="handbook.html#organization-setup"></keyword>
+          <keyword text="Repo setup" href="handbook.html#repo-setup"></keyword>
+          <keyword text="Issue tracker setup" href="handbook.html#issue-tracker-setup"></keyword>
+          <keyword text="Guidelines for Task Tracking using the Issue Tracker" href="handbook.html#project-schedule-tracking"></keyword>
+          <keyword text="[Optional] A safer workflow using forks and pull requests" href="handbook.html#workflow"></keyword>
         </main-category>
-        <main-category text="Appendix F: What to do if there are teamwork issues" type="primary" label="Handbook" href="handbook.html#handbook-appendixF">
-          <keyword text="What to do if my team is facing difficulties due to differences in skill/motivation/availability among team members" href="handbook.html#handbook-appendixF"></keyword>
-          <keyword text="What to do if I have very unreliable or totally disengaged team members " href="handbook.html#handbook-appendixF"></keyword>
+        <main-category text="Appendix F: What to do if there are teamwork issues" type="primary" label="Handbook" href="handbook.html#handbook-appendixF-teamworkIssues">
+          <keyword text="What to do if my team is facing difficulties due to differences in skill/motivation/availability among team members" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
+          <keyword text="What to do if I have very unreliable or totally disengaged team members " href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
           <category text="Suggestions">
-            <keyword text="Redistribute the work" href="handbook.html#handbook-appendixF"></keyword>
-            <keyword text="Enforce stricter integration workflow" href="handbook.html#handbook-appendixF"></keyword>
+            <keyword text="Redistribute the work" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
+            <keyword text="Enforce stricter integration workflow" href="handbook.html#handbook-appendixF-teamworkIssues"></keyword>
           </category>
         </main-category>
         <main-category text="Overview" href="schedule.html#header-content-week0" label="Schedule" type="warning">
@@ -301,23 +291,22 @@
         </main-category>
         <main-category text="Week 2" href="schedule.html#header-content-week2" label="Schedule" type="warning">
           <category text="Pre-tutorial learning activities">
-            <keyword text="Get started with IDEs" href="schedule.html#header-content-week2"></keyword>
-            <keyword text="Start using a task management tool" href="schedule.html#header-content-week2"></keyword>
-            <keyword text="Brainstorm user stories" href="schedule.html#header-content-week2"></keyword>
+            <keyword text="Get started with IDEs" href="schedule.html#activity-content-week2"></keyword>
+            <keyword text="Debugging in IDEs" href="schedule.html#activity-content-week2"></keyword>
+            <keyword text="Start using a task management tool" href="schedule.html#activity-content-week2"></keyword>
+            <keyword text="Regression testing using text input/output" href="schedule.html#activity-content-week2"></keyword>
+            <keyword text="Use Java Collections, Enums, Varargs" href="schedule.html#activity-content-week2"></keyword>
           </category>
-          <category text="Tutorial 2: user stories">
-            <keyword text="Consolidate user stories" href="schedule.html#header-content-week2"></keyword>
+          <category text="Tutorial 1: IDE Usage">
+            <keyword text="Forming teams" href="schedule.html#tutorial-content-week2"></keyword>
+            <keyword text="Demo results of pre-tutorial learning activities" href="schedule.html#tutorial-content-week2"></keyword>
           </category>
-          <category text="Intended learning outcomes">
-            <keyword text="Knows the pros and cons of the SE field" href="schedule.html#header-content-week2"></keyword>
-            <keyword text="Able to use user stories to record user needs" href="schedule.html#header-content-week2"></keyword>
-          </category>
-          <keyword text="Lecture 2 Part 1 - Good code, bad code: Toward production quality code" href="schedule.html#header-content-week2"></keyword>
+          <keyword text="Lecture 2 Part 1 - Good code, bad code: Toward production quality code" href="schedule.html#lecture-content-week2"></keyword>
           <category text="Lecture 2 Part 2 - Refactoring: from Turkey to Peacock in thousand steps">
-            <keyword text="Noteworthy resources: How much refactoring should I do? " href="schedule.html#header-content-week2"></keyword>
+            <keyword text="Noteworthy resources: How much refactoring should I do? " href="schedule.html#lecture-content-week2"></keyword>
           </category>
           <category text="Lecture 2 Part 3 - Your own private time machine: Introduction to revision control">
-            <keyword text="Noteworthy resources: Getting started with Git" href="schedule.html#header-content-week2"></keyword>
+            <keyword text="Noteworthy resources: Getting started with Git" href="schedule.html#lecture-content-week2"></keyword>
           </category>
         </main-category>
         <main-category text="Week 3" href="schedule.html#header-content-week3" label="Schedule" type="warning">

--- a/scripts/handbook.js
+++ b/scripts/handbook.js
@@ -157,6 +157,10 @@ function loadSections() {
     } else {
         var callback = function() {
             $('#overlay').remove();
+            // If there is an anchor tag in url, make sure to jump to the specific section.
+            if (location.hash) {
+                location.href = location.hash;
+            }
         }
         loadAllSectionsUsingAjax(callback);
         addJumpToSectionHeadingBehavior($('a'));


### PR DESCRIPTION
Fixes #221 
Preview: http://rawgit.com/zeulb/website/221-fix-broken-links-in-search/contents/search.html

Possibly things to do before the search page can be deployed:
- Link with anchor doesn't expand the content anymore in schedule page (Ex: http://nus-cs2103.github.io/website/contents/schedule.html#activity-content-week2)
- Add search contents from other weeks in schedule page