### PR TITLE
Auto expand content for anchored links to schedule page #237

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -244,9 +244,20 @@ function loadContent(week) {
 
             if (++weeksLoaded == totalWeeks) {
                 $.getScript('../scripts/tooltip.js');
+                expandSectionForAnchor(location.hash);
             }
         }
     });
+}
+
+/**
+ * Expands the section as referenced by an anchored link.
+ * Reveal the section if nested, then expand the section.
+ * If anchor is empty string, this function does nothing.
+ */
+function expandSectionForAnchor(anchor) {
+    $(anchor).parent().parent().prev('.ui-accordion-header').click();
+    $(anchor).find('.btn-expand').click();
 }
 
 function addAutoExpandSubheadingsBehaviour(component) {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -256,8 +256,15 @@ function loadContent(week) {
  * If anchor is empty string, this function does nothing.
  */
 function expandSectionForAnchor(anchor) {
-    $(anchor).parent().parent().prev('.ui-accordion-header').click();
-    $(anchor).find('.btn-expand').click();
+    var headers = $(anchor).parents('.ui-accordion-content').prev('.ui-accordion-header');
+    headers.click();
+    $(anchor).click();
+
+    setTimeout(function() {
+        var headerHeight = headers.last().outerHeight();
+        var position = $(anchor).offset().top - headerHeight;
+        $(window).scrollTop(position);
+    }, 500); // Wait for scroll animation in "addAutoScrollToClickedWeekHeader"
 }
 
 function addAutoExpandSubheadingsBehaviour(component) {


### PR DESCRIPTION
Fixes #237
Previews:
- [.../contents/schedule.html#header-content-week2](http://rawgit.com/acjh/website/237-auto-expand-anchor-schedule/contents/schedule.html#header-content-week2)
- [.../contents/schedule.html#activity-content-week2](http://rawgit.com/acjh/website/237-auto-expand-anchor-schedule/contents/schedule.html#activity-content-week2) (nested section)