### PR TITLE
Fix syntax highlighting info in ContentAuthorGuide.md

### DIFF
--- a/doc/ContentAuthorGuide.md
+++ b/doc/ContentAuthorGuide.md
@@ -79,7 +79,7 @@ Use `<code>` tags to represent fragments of computer code in monospace font.
 
 ### Syntax Highlighting
 Language-specific syntax highlighting is achieved by enclosing code samples in:  
-`<pre class="prettyprint"><code class="language-java>` `</code></pre>`  
+`<pre class="prettyprint"><code class="language-java">` `</code></pre>`  
 > Other valid code classes: `lang-html`, `shell`
 
 ### Difficulty Stars

--- a/doc/ContentAuthorGuide.md
+++ b/doc/ContentAuthorGuide.md
@@ -79,7 +79,9 @@ Use `<code>` tags to represent fragments of computer code in monospace font.
 
 ### Syntax Highlighting
 Language-specific syntax highlighting is achieved by enclosing code samples in:  
-`<pre class="prettyprint"><code class="language-java">` `</code></pre>`  
+```html
+<pre class="prettyprint"><code class="language-java"> </code></pre>
+```
 > Other valid code classes: `lang-html`, `shell`
 
 ### Difficulty Stars


### PR DESCRIPTION
Fixes the error in PR #239
[Preview](https://github.com/acjh/website/blob/234-fix-syntax-highlighting-info/doc/ContentAuthorGuide.md#syntax-highlighting)