### PR TITLE
Style embedded links differently from normal links #225

### DIFF
--- a/styles/common.css
+++ b/styles/common.css
@@ -432,7 +432,7 @@ table.two-column-content td {
  */
 
 .embedded-link {
-    color: blue;
+    color: darkblue;
     text-decoration: underline;
     font-style: italic;
     cursor: pointer;

--- a/styles/common.css
+++ b/styles/common.css
@@ -434,6 +434,7 @@ table.two-column-content td {
 .embedded-link {
     color: blue;
     text-decoration: underline;
+    font-style: italic;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes issue: #225 

Staging site: https://rawgit.com/MasterFelix15/website/225-differentiate-embedded-links/index.html

The website now displays the embedded links in dark blue and in italic.